### PR TITLE
Fix volumes and rename service name

### DIFF
--- a/jenkins/app.yaml
+++ b/jenkins/app.yaml
@@ -1,27 +1,4 @@
 apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: jenkins-pv
-  namespace: apps
-  labels:
-    name: jenkins-data
-    type: longhorn
-spec:
-  capacity:
-    storage: $VOLUME_SIZE
-  volumeMode: Filesystem
-  storageClassName: longhorn
-  accessModes:
-    - ReadWriteOnce
-  csi:
-    driver: io.rancher.longhorn
-    fsType: ext4
-    volumeAttributes:
-      numberOfReplicates: '2'
-      staleReplicaTimeout: '20'
-    volumeHandle: jenkins-data
----
-apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: jenkins-pv-claim
@@ -39,7 +16,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: jenkins
+  name: jenkins-frontend
 spec:
   ports:
   - name: jenkins

--- a/jenkins/post_install.md
+++ b/jenkins/post_install.md
@@ -16,7 +16,7 @@ spec:
       paths:
       - backend:
           serviceName: jenkins-frontend
-          servicePort: 80
+          servicePort: 8080
 ```
 
 This will open up http://jenkins.YOUR_CLUSTER_ID.k8s.civo.com to the whole world. You should lock this down in the [firewall](https://www.civo.com/account/firewalls) automatically created in Civo for your Kubernetes cluster. Locking down the firewall will only affect access from OUTSIDE of your Kubernetes cluster, access from your applications within Kubernetes will not be affected.


### PR DESCRIPTION
Pod gets stuck in `ContainerCreating` state. After referencing Racher's docs, only `PersistentVolumeClaim` is required.

changes:

- fix service name and port
- referenced longhorns example and noticed that only PersistentVolumeClaim section is needed (https://github.com/longhorn/longhorn/blob/master/examples/deployment.yaml)

