### PR TITLE
Upgrade prometheus-operator chart

### DIFF
--- a/prometheus-operator/app.yaml
+++ b/prometheus-operator/app.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: alertmanagers.monitoring.coreos.com
+  labels:
+    app: prometheus-operator
 spec:
   group: monitoring.coreos.com
   names:
@@ -16,12 +18,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
           description: 'AlertmanagerSpec is a specification of the desired behavior
@@ -95,7 +97,6 @@ spec:
                                   required:
                                   - key
                                   - operator
-                                  type: object
                                 type: array
                               matchFields:
                                 description: A list of node selector requirements
@@ -129,9 +130,7 @@ spec:
                                   required:
                                   - key
                                   - operator
-                                  type: object
                                 type: array
-                            type: object
                           weight:
                             description: Weight associated with matching the corresponding
                               nodeSelectorTerm, in the range 1-100.
@@ -140,7 +139,6 @@ spec:
                         required:
                         - weight
                         - preference
-                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: A node selector represents the union of the results
@@ -189,7 +187,6 @@ spec:
                                   required:
                                   - key
                                   - operator
-                                  type: object
                                 type: array
                               matchFields:
                                 description: A list of node selector requirements
@@ -223,14 +220,10 @@ spec:
                                   required:
                                   - key
                                   - operator
-                                  type: object
                                 type: array
-                            type: object
                           type: array
                       required:
                       - nodeSelectorTerms
-                      type: object
-                  type: object
                 podAffinity:
                   description: Pod affinity is a group of inter pod affinity scheduling
                     rules.
@@ -297,7 +290,6 @@ spec:
                                       required:
                                       - key
                                       - operator
-                                      type: object
                                     type: array
                                   matchLabels:
                                     description: matchLabels is a map of {key,value}
@@ -307,7 +299,6 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
-                                type: object
                               namespaces:
                                 description: namespaces specifies which namespaces
                                   the labelSelector applies to (matches against);
@@ -326,7 +317,6 @@ spec:
                                 type: string
                             required:
                             - topologyKey
-                            type: object
                           weight:
                             description: weight associated with matching the corresponding
                               podAffinityTerm, in the range 1-100.
@@ -335,7 +325,6 @@ spec:
                         required:
                         - weight
                         - podAffinityTerm
-                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: If the affinity requirements specified by this
@@ -392,7 +381,6 @@ spec:
                                   required:
                                   - key
                                   - operator
-                                  type: object
                                 type: array
                               matchLabels:
                                 description: matchLabels is a map of {key,value} pairs.
@@ -401,7 +389,6 @@ spec:
                                   is "key", the operator is "In", and the values array
                                   contains only "value". The requirements are ANDed.
                                 type: object
-                            type: object
                           namespaces:
                             description: namespaces specifies which namespaces the
                               labelSelector applies to (matches against); null or
@@ -420,9 +407,7 @@ spec:
                             type: string
                         required:
                         - topologyKey
-                        type: object
                       type: array
-                  type: object
                 podAntiAffinity:
                   description: Pod anti affinity is a group of inter pod anti affinity
                     scheduling rules.
@@ -490,7 +475,6 @@ spec:
                                       required:
                                       - key
                                       - operator
-                                      type: object
                                     type: array
                                   matchLabels:
                                     description: matchLabels is a map of {key,value}
@@ -500,7 +484,6 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
-                                type: object
                               namespaces:
                                 description: namespaces specifies which namespaces
                                   the labelSelector applies to (matches against);
@@ -519,7 +502,6 @@ spec:
                                 type: string
                             required:
                             - topologyKey
-                            type: object
                           weight:
                             description: weight associated with matching the corresponding
                               podAffinityTerm, in the range 1-100.
@@ -528,7 +510,6 @@ spec:
                         required:
                         - weight
                         - podAffinityTerm
-                        type: object
                       type: array
                     requiredDuringSchedulingIgnoredDuringExecution:
                       description: If the anti-affinity requirements specified by
@@ -585,7 +566,6 @@ spec:
                                   required:
                                   - key
                                   - operator
-                                  type: object
                                 type: array
                               matchLabels:
                                 description: matchLabels is a map of {key,value} pairs.
@@ -594,7 +574,6 @@ spec:
                                   is "key", the operator is "In", and the values array
                                   contains only "value". The requirements are ANDed.
                                 type: object
-                            type: object
                           namespaces:
                             description: namespaces specifies which namespaces the
                               labelSelector applies to (matches against); null or
@@ -613,10 +592,7 @@ spec:
                             type: string
                         required:
                         - topologyKey
-                        type: object
                       type: array
-                  type: object
-              type: object
             baseImage:
               description: Base image that is used to deploy pods, without tag.
               type: string
@@ -694,12 +670,11 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description: Specify whether the ConfigMap or it's
                                     key must be defined
                                   type: boolean
                               required:
                               - key
-                              type: object
                             fieldRef:
                               description: ObjectFieldSelector selects an APIVersioned
                                 field of an object.
@@ -714,7 +689,6 @@ spec:
                                   type: string
                               required:
                               - fieldPath
-                              type: object
                             resourceFieldRef:
                               description: ResourceFieldSelector represents container
                                 resources (cpu, memory) and their output format
@@ -729,7 +703,6 @@ spec:
                                   type: string
                               required:
                               - resource
-                              type: object
                             secretKeyRef:
                               description: SecretKeySelector selects a key of a Secret.
                               properties:
@@ -741,16 +714,13 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
-                              type: object
-                          type: object
                       required:
                       - name
-                      type: object
                     type: array
                   envFrom:
                     description: List of sources to populate environment variables
@@ -767,7 +737,6 @@ spec:
                         configMapRef:
                           description: |-
                             ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
-
                             The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
                           properties:
                             name:
@@ -776,7 +745,6 @@ spec:
                             optional:
                               description: Specify whether the ConfigMap must be defined
                               type: boolean
-                          type: object
                         prefix:
                           description: An optional identifier to prepend to each key
                             in the ConfigMap. Must be a C_IDENTIFIER.
@@ -784,7 +752,6 @@ spec:
                         secretRef:
                           description: |-
                             SecretEnvSource selects a Secret to populate the environment variables with.
-
                             The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
                           properties:
                             name:
@@ -793,8 +760,6 @@ spec:
                             optional:
                               description: Specify whether the Secret must be defined
                               type: boolean
-                          type: object
-                      type: object
                     type: array
                   image:
                     description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
@@ -834,7 +799,6 @@ spec:
                                 items:
                                   type: string
                                 type: array
-                            type: object
                           httpGet:
                             description: HTTPGetAction describes an action based on
                               HTTP Get requests.
@@ -860,7 +824,6 @@ spec:
                                   required:
                                   - name
                                   - value
-                                  type: object
                                 type: array
                               path:
                                 description: Path to access on the HTTP server.
@@ -875,7 +838,6 @@ spec:
                                 type: string
                             required:
                             - port
-                            type: object
                           tcpSocket:
                             description: TCPSocketAction describes an action based
                               on opening a socket
@@ -890,8 +852,6 @@ spec:
                                 - type: integer
                             required:
                             - port
-                            type: object
-                        type: object
                       preStop:
                         description: Handler defines a specific action that should
                           be taken
@@ -912,7 +872,6 @@ spec:
                                 items:
                                   type: string
                                 type: array
-                            type: object
                           httpGet:
                             description: HTTPGetAction describes an action based on
                               HTTP Get requests.
@@ -938,7 +897,6 @@ spec:
                                   required:
                                   - name
                                   - value
-                                  type: object
                                 type: array
                               path:
                                 description: Path to access on the HTTP server.
@@ -953,7 +911,6 @@ spec:
                                 type: string
                             required:
                             - port
-                            type: object
                           tcpSocket:
                             description: TCPSocketAction describes an action based
                               on opening a socket
@@ -968,9 +925,6 @@ spec:
                                 - type: integer
                             required:
                             - port
-                            type: object
-                        type: object
-                    type: object
                   livenessProbe:
                     description: Probe describes a health check to be performed against
                       a container to determine whether it is alive or ready to receive
@@ -991,7 +945,6 @@ spec:
                             items:
                               type: string
                             type: array
-                        type: object
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
@@ -1023,7 +976,6 @@ spec:
                               required:
                               - name
                               - value
-                              type: object
                             type: array
                           path:
                             description: Path to access on the HTTP server.
@@ -1038,7 +990,6 @@ spec:
                             type: string
                         required:
                         - port
-                        type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
                           before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -1052,8 +1003,7 @@ spec:
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          1. Must be 1 for liveness. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -1070,14 +1020,12 @@ spec:
                             - type: integer
                         required:
                         - port
-                        type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
                           out. Defaults to 1 second. Minimum value is 1. More info:
                           https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
-                    type: object
                   name:
                     description: Name of the container specified as a DNS_LABEL. Each
                       container in a pod must have a unique name (DNS_LABEL). Cannot
@@ -1122,7 +1070,6 @@ spec:
                           type: string
                       required:
                       - containerPort
-                      type: object
                     type: array
                   readinessProbe:
                     description: Probe describes a health check to be performed against
@@ -1144,7 +1091,6 @@ spec:
                             items:
                               type: string
                             type: array
-                        type: object
                       failureThreshold:
                         description: Minimum consecutive failures for the probe to
                           be considered failed after having succeeded. Defaults to
@@ -1176,7 +1122,6 @@ spec:
                               required:
                               - name
                               - value
-                              type: object
                             type: array
                           path:
                             description: Path to access on the HTTP server.
@@ -1191,7 +1136,6 @@ spec:
                             type: string
                         required:
                         - port
-                        type: object
                       initialDelaySeconds:
                         description: 'Number of seconds after the container has started
                           before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
@@ -1205,8 +1149,7 @@ spec:
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          1. Must be 1 for liveness. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -1223,14 +1166,12 @@ spec:
                             - type: integer
                         required:
                         - port
-                        type: object
                       timeoutSeconds:
                         description: 'Number of seconds after which the probe times
                           out. Defaults to 1 second. Minimum value is 1. More info:
                           https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                         format: int32
                         type: integer
-                    type: object
                   resources:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -1245,7 +1186,6 @@ spec:
                           it defaults to Limits if that is explicitly specified, otherwise
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
-                    type: object
                   securityContext:
                     description: SecurityContext holds security configuration that
                       will be applied to a container. Some fields are present in both
@@ -1274,7 +1214,6 @@ spec:
                             items:
                               type: string
                             type: array
-                        type: object
                       privileged:
                         description: Run container in privileged mode. Processes in
                           privileged containers are essentially equivalent to root
@@ -1336,144 +1275,6 @@ spec:
                             description: User is a SELinux user label that applies
                               to the container.
                             type: string
-                        type: object
-                      windowsOptions:
-                        description: WindowsSecurityContextOptions contain Windows-specific
-                          options and credentials.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. This field is alpha-level and it is
-                              only honored by servers that enable the WindowsRunAsUserName
-                              feature flag.
-                            type: string
-                        type: object
-                    type: object
-                  startupProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
                   stdin:
                     description: Whether this container should allocate a buffer for
                       stdin in the container runtime. If this is not set, reads from
@@ -1531,7 +1332,6 @@ spec:
                       required:
                       - name
                       - devicePath
-                      type: object
                     type: array
                   volumeMounts:
                     description: Pod volumes to mount into the container's filesystem.
@@ -1561,18 +1361,9 @@ spec:
                           description: Path within the volume from which the container's
                             volume should be mounted. Defaults to "" (volume's root).
                           type: string
-                        subPathExpr:
-                          description: Expanded path within the volume from which
-                            the container's volume should be mounted. Behaves similarly
-                            to SubPath but environment variable references $(VAR_NAME)
-                            are expanded using the container's environment. Defaults
-                            to "" (volume's root). SubPathExpr and SubPath are mutually
-                            exclusive. This field is beta in 1.15.
-                          type: string
                       required:
                       - name
                       - mountPath
-                      type: object
                     type: array
                   workingDir:
                     description: Container's working directory. If not specified,
@@ -1581,7 +1372,6 @@ spec:
                     type: string
                 required:
                 - name
-                type: object
               type: array
             externalUrl:
               description: The external URL the Alertmanager instances will be available
@@ -1605,978 +1395,12 @@ spec:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                type: object
-              type: array
-            initContainers:
-              description: 'InitContainers allows adding initContainers to the pod
-                definition. Those can be used to e.g. fetch secrets for injection
-                into the Alertmanager configuration from external sources. Any errors
-                during the execution of an initContainer will lead to a restart of
-                the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-                Using initContainers for any use case other then secret fetching is
-                entirely outside the scope of what the maintainers will support and
-                by doing so, you accept that this behaviour may break at any time
-                without notice.'
-              items:
-                description: A single application container that you want to run within
-                  a pod.
-                properties:
-                  args:
-                    description: 'Arguments to the entrypoint. The docker image''s
-                      CMD is used if this is not provided. Variable references $(VAR_NAME)
-                      are expanded using the container''s environment. If a variable
-                      cannot be resolved, the reference in the input string will be
-                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
-                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                      regardless of whether the variable exists or not. Cannot be
-                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                    items:
-                      type: string
-                    type: array
-                  command:
-                    description: 'Entrypoint array. Not executed within a shell. The
-                      docker image''s ENTRYPOINT is used if this is not provided.
-                      Variable references $(VAR_NAME) are expanded using the container''s
-                      environment. If a variable cannot be resolved, the reference
-                      in the input string will be unchanged. The $(VAR_NAME) syntax
-                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                      will never be expanded, regardless of whether the variable exists
-                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                    items:
-                      type: string
-                    type: array
-                  env:
-                    description: List of environment variables to set in the container.
-                      Cannot be updated.
-                    items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
-                      properties:
-                        name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
-                          type: string
-                        value:
-                          description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                          type: string
-                        valueFrom:
-                          description: EnvVarSource represents a source for the value
-                            of an EnvVar.
-                          properties:
-                            configMapKeyRef:
-                              description: Selects a key from a ConfigMap.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                            fieldRef:
-                              description: ObjectFieldSelector selects an APIVersioned
-                                field of an object.
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            resourceFieldRef:
-                              description: ResourceFieldSelector represents container
-                                resources (cpu, memory) and their output format
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor: {}
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                            secretKeyRef:
-                              description: SecretKeySelector selects a key of a Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  envFrom:
-                    description: List of sources to populate environment variables
-                      in the container. The keys defined within a source must be a
-                      C_IDENTIFIER. All invalid keys will be reported as an event
-                      when the container is starting. When a key exists in multiple
-                      sources, the value associated with the last source will take
-                      precedence. Values defined by an Env with a duplicate key will
-                      take precedence. Cannot be updated.
-                    items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps
-                      properties:
-                        configMapRef:
-                          description: |-
-                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
-
-                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap must be defined
-                              type: boolean
-                          type: object
-                        prefix:
-                          description: An optional identifier to prepend to each key
-                            in the ConfigMap. Must be a C_IDENTIFIER.
-                          type: string
-                        secretRef:
-                          description: |-
-                            SecretEnvSource selects a Secret to populate the environment variables with.
-
-                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret must be defined
-                              type: boolean
-                          type: object
-                      type: object
-                    type: array
-                  image:
-                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                      This field is optional to allow higher level config management
-                      to default or override container images in workload controllers
-                      like Deployments and StatefulSets.'
-                    type: string
-                  imagePullPolicy:
-                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                      Defaults to Always if :latest tag is specified, or IfNotPresent
-                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                    type: string
-                  lifecycle:
-                    description: Lifecycle describes actions that the management system
-                      should take in response to container lifecycle events. For the
-                      PostStart and PreStop lifecycle handlers, management of the
-                      container blocks until the action is complete, unless the container
-                      process fails, in which case the handler is aborted.
-                    properties:
-                      postStart:
-                        description: Handler defines a specific action that should
-                          be taken
-                        properties:
-                          exec:
-                            description: ExecAction describes a "run in container"
-                              action.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          httpGet:
-                            description: HTTPGetAction describes an action based on
-                              HTTP Get requests.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          tcpSocket:
-                            description: TCPSocketAction describes an action based
-                              on opening a socket
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                        type: object
-                      preStop:
-                        description: Handler defines a specific action that should
-                          be taken
-                        properties:
-                          exec:
-                            description: ExecAction describes a "run in container"
-                              action.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          httpGet:
-                            description: HTTPGetAction describes an action based on
-                              HTTP Get requests.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          tcpSocket:
-                            description: TCPSocketAction describes an action based
-                              on opening a socket
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                        type: object
-                    type: object
-                  livenessProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  name:
-                    description: Name of the container specified as a DNS_LABEL. Each
-                      container in a pod must have a unique name (DNS_LABEL). Cannot
-                      be updated.
-                    type: string
-                  ports:
-                    description: List of ports to expose from the container. Exposing
-                      a port here gives the system additional information about the
-                      network connections a container uses, but is primarily informational.
-                      Not specifying a port here DOES NOT prevent that port from being
-                      exposed. Any port which is listening on the default "0.0.0.0"
-                      address inside a container will be accessible from the network.
-                      Cannot be updated.
-                    items:
-                      description: ContainerPort represents a network port in a single
-                        container.
-                      properties:
-                        containerPort:
-                          description: Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
-                          format: int32
-                          type: integer
-                        hostIP:
-                          description: What host IP to bind the external port to.
-                          type: string
-                        hostPort:
-                          description: Number of port to expose on the host. If specified,
-                            this must be a valid port number, 0 < x < 65536. If HostNetwork
-                            is specified, this must match ContainerPort. Most containers
-                            do not need this.
-                          format: int32
-                          type: integer
-                        name:
-                          description: If specified, this must be an IANA_SVC_NAME
-                            and unique within the pod. Each named port in a pod must
-                            have a unique name. Name for the port that can be referred
-                            to by services.
-                          type: string
-                        protocol:
-                          description: Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
-                          type: string
-                      required:
-                      - containerPort
-                      type: object
-                    type: array
-                  readinessProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      limits:
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                  securityContext:
-                    description: SecurityContext holds security configuration that
-                      will be applied to a container. Some fields are present in both
-                      SecurityContext and PodSecurityContext.  When both are set,
-                      the values in SecurityContext take precedence.
-                    properties:
-                      allowPrivilegeEscalation:
-                        description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                        type: boolean
-                      capabilities:
-                        description: Adds and removes POSIX capabilities from running
-                          containers.
-                        properties:
-                          add:
-                            description: Added capabilities
-                            items:
-                              type: string
-                            type: array
-                          drop:
-                            description: Removed capabilities
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      privileged:
-                        description: Run container in privileged mode. Processes in
-                          privileged containers are essentially equivalent to root
-                          on the host. Defaults to false.
-                        type: boolean
-                      procMount:
-                        description: procMount denotes the type of proc mount to use
-                          for the containers. The default is DefaultProcMount which
-                          uses the container runtime defaults for readonly paths and
-                          masked paths. This requires the ProcMountType feature flag
-                          to be enabled.
-                        type: string
-                      readOnlyRootFilesystem:
-                        description: Whether this container has a read-only root filesystem.
-                          Default is false.
-                        type: boolean
-                      runAsGroup:
-                        description: The GID to run the entrypoint of the container
-                          process. Uses runtime default if unset. May also be set
-                          in PodSecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        description: Indicates that the container must run as a non-root
-                          user. If true, the Kubelet will validate the image at runtime
-                          to ensure that it does not run as UID 0 (root) and fail
-                          to start the container if it does. If unset or false, no
-                          such validation will be performed. May also be set in PodSecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        type: boolean
-                      runAsUser:
-                        description: The UID to run the entrypoint of the container
-                          process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in PodSecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        description: SELinuxOptions are the labels to be applied to
-                          the container
-                        properties:
-                          level:
-                            description: Level is SELinux level label that applies
-                              to the container.
-                            type: string
-                          role:
-                            description: Role is a SELinux role label that applies
-                              to the container.
-                            type: string
-                          type:
-                            description: Type is a SELinux type label that applies
-                              to the container.
-                            type: string
-                          user:
-                            description: User is a SELinux user label that applies
-                              to the container.
-                            type: string
-                        type: object
-                      windowsOptions:
-                        description: WindowsSecurityContextOptions contain Windows-specific
-                          options and credentials.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. This field is alpha-level and it is
-                              only honored by servers that enable the WindowsRunAsUserName
-                              feature flag.
-                            type: string
-                        type: object
-                    type: object
-                  startupProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  stdin:
-                    description: Whether this container should allocate a buffer for
-                      stdin in the container runtime. If this is not set, reads from
-                      stdin in the container will always result in EOF. Default is
-                      false.
-                    type: boolean
-                  stdinOnce:
-                    description: Whether the container runtime should close the stdin
-                      channel after it has been opened by a single attach. When stdin
-                      is true the stdin stream will remain open across multiple attach
-                      sessions. If stdinOnce is set to true, stdin is opened on container
-                      start, is empty until the first client attaches to stdin, and
-                      then remains open and accepts data until the client disconnects,
-                      at which time stdin is closed and remains closed until the container
-                      is restarted. If this flag is false, a container processes that
-                      reads from stdin will never receive an EOF. Default is false
-                    type: boolean
-                  terminationMessagePath:
-                    description: 'Optional: Path at which the file to which the container''s
-                      termination message will be written is mounted into the container''s
-                      filesystem. Message written is intended to be brief final status,
-                      such as an assertion failure message. Will be truncated by the
-                      node if greater than 4096 bytes. The total message length across
-                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
-                      Cannot be updated.'
-                    type: string
-                  terminationMessagePolicy:
-                    description: Indicate how the termination message should be populated.
-                      File will use the contents of terminationMessagePath to populate
-                      the container status message on both success and failure. FallbackToLogsOnError
-                      will use the last chunk of container log output if the termination
-                      message file is empty and the container exited with an error.
-                      The log output is limited to 2048 bytes or 80 lines, whichever
-                      is smaller. Defaults to File. Cannot be updated.
-                    type: string
-                  tty:
-                    description: Whether this container should allocate a TTY for
-                      itself, also requires 'stdin' to be true. Default is false.
-                    type: boolean
-                  volumeDevices:
-                    description: volumeDevices is the list of block devices to be
-                      used by the container. This is a beta feature.
-                    items:
-                      description: volumeDevice describes a mapping of a raw block
-                        device within a container.
-                      properties:
-                        devicePath:
-                          description: devicePath is the path inside of the container
-                            that the device will be mapped to.
-                          type: string
-                        name:
-                          description: name must match the name of a persistentVolumeClaim
-                            in the pod
-                          type: string
-                      required:
-                      - name
-                      - devicePath
-                      type: object
-                    type: array
-                  volumeMounts:
-                    description: Pod volumes to mount into the container's filesystem.
-                      Cannot be updated.
-                    items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
-                      properties:
-                        mountPath:
-                          description: Path within the container at which the volume
-                            should be mounted.  Must not contain ':'.
-                          type: string
-                        mountPropagation:
-                          description: mountPropagation determines how mounts are
-                            propagated from the host to container and the other way
-                            around. When not set, MountPropagationNone is used. This
-                            field is beta in 1.10.
-                          type: string
-                        name:
-                          description: This must match the Name of a Volume.
-                          type: string
-                        readOnly:
-                          description: Mounted read-only if true, read-write otherwise
-                            (false or unspecified). Defaults to false.
-                          type: boolean
-                        subPath:
-                          description: Path within the volume from which the container's
-                            volume should be mounted. Defaults to "" (volume's root).
-                          type: string
-                        subPathExpr:
-                          description: Expanded path within the volume from which
-                            the container's volume should be mounted. Behaves similarly
-                            to SubPath but environment variable references $(VAR_NAME)
-                            are expanded using the container's environment. Defaults
-                            to "" (volume's root). SubPathExpr and SubPath are mutually
-                            exclusive. This field is beta in 1.15.
-                          type: string
-                      required:
-                      - name
-                      - mountPath
-                      type: object
-                    type: array
-                  workingDir:
-                    description: Container's working directory. If not specified,
-                      the container runtime's default will be used, which might be
-                      configured in the container image. Cannot be updated.
-                    type: string
-                required:
-                - name
-                type: object
               type: array
             listenLocal:
               description: ListenLocal makes the Alertmanager server listen on loopback,
                 so that it does not bind against the Pod IP. Note this is only for
                 the Alertmanager UI, not the gossip communication.
               type: boolean
-            logFormat:
-              description: Log format for Alertmanager to be configured with.
-              type: string
             logLevel:
               description: Log level for Alertmanager to be configured with.
               type: string
@@ -2633,72 +1457,172 @@ spec:
                 generateName:
                   description: |-
                     GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-
                     If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
-
-                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                   type: string
                 generation:
                   description: A sequence number representing a specific generation
                     of the desired state. Populated by the system. Read-only.
                   format: int64
                   type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                  required:
+                  - pending
                 labels:
                   description: 'Map of string keys and values that can be used to
                     organize and categorize (scope and select) objects. May match
                     selectors of replication controllers and services. More info:
                     http://kubernetes.io/docs/user-guide/labels'
                   type: object
-                managedFields:
-                  description: ManagedFields maps workflow-id and version to the set
-                    of fields that are managed by that workflow. This is mostly for
-                    internal housekeeping, and users typically shouldn't need to set
-                    or understand this field. A workflow can be the user's name, a
-                    controller's name, or the name of a specific apply path like "ci-cd".
-                    The set of fields is always in the version that the workflow used
-                    when modifying the object.
-                  items:
-                    description: ManagedFieldsEntry is a workflow-id, a FieldSet and
-                      the group version of the resource that the fieldset applies
-                      to.
-                    properties:
-                      apiVersion:
-                        description: APIVersion defines the version of this resource
-                          that this field set applies to. The format is "group/version"
-                          just like the top-level APIVersion field. It is necessary
-                          to track the version of a field set because it cannot be
-                          automatically converted.
-                        type: string
-                      fieldsType:
-                        description: 'FieldsType is the discriminator for the different
-                          fields format and version. There is currently only one possible
-                          value: "FieldsV1"'
-                        type: string
-                      fieldsV1:
-                        description: |-
-                          FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
-
-                          Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
-
-                          The exact format is defined in sigs.k8s.io/structured-merge-diff
-                        type: object
-                      manager:
-                        description: Manager is an identifier of the workflow managing
-                          these fields.
-                        type: string
-                      operation:
-                        description: Operation is the type of operation which lead
-                          to this ManagedFieldsEntry being created. The only valid
-                          values for this field are 'Apply' and 'Update'.
-                        type: string
-                      time:
-                        description: Time is a wrapper around time.Time which supports
-                          correct marshaling to YAML and JSON.  Wrappers are provided
-                          for many of the factory methods that the time package offers.
-                        format: date-time
-                        type: string
-                    type: object
-                  type: array
                 name:
                   description: 'Name must be unique within a namespace. Is required
                     when creating resources, although some resources may allow a client
@@ -2709,7 +1633,6 @@ spec:
                 namespace:
                   description: |-
                     Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-
                     Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                   type: string
                 ownerReferences:
@@ -2739,7 +1662,7 @@ spec:
                           controller.
                         type: boolean
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                         type: string
                       name:
                         description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -2752,31 +1675,21 @@ spec:
                     - kind
                     - name
                     - uid
-                    type: object
                   type: array
                 resourceVersion:
                   description: |-
                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-
-                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                   type: string
                 selfLink:
-                  description: |-
-                    SelfLink is a URL representing this object. Populated by the system. Read-only.
-
-                    DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
                   type: string
                 uid:
                   description: |-
                     UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-
                     Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                   type: string
-              type: object
-            portName:
-              description: Port name used for the pods and governing service. This
-                defaults to web
-              type: string
             priorityClassName:
               description: Priority class assigned to the Pods
               type: string
@@ -2799,7 +1712,6 @@ spec:
                     to Limits if that is explicitly specified, otherwise to an implementation-defined
                     value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                   type: object
-              type: object
             retention:
               description: Time duration Alertmanager shall retain data for. Default
                 is '120h', and must match the regular expression `[0-9]+(ms|s|m|h)`
@@ -2828,9 +1740,7 @@ spec:
                 fsGroup:
                   description: |-
                     A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
-
                     1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
-
                     If unset, the Kubelet will not modify the ownership and permissions of any volume.
                   format: int64
                   type: integer
@@ -2878,7 +1788,6 @@ spec:
                       description: User is a SELinux user label that applies to the
                         container.
                       type: string
-                  type: object
                 supplementalGroups:
                   description: A list of groups applied to the first process run in
                     each container, in addition to the container's primary GID.  If
@@ -2903,36 +1812,7 @@ spec:
                     required:
                     - name
                     - value
-                    type: object
                   type: array
-                windowsOptions:
-                  description: WindowsSecurityContextOptions contain Windows-specific
-                    options and credentials.
-                  properties:
-                    gmsaCredentialSpec:
-                      description: GMSACredentialSpec is where the GMSA admission
-                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                        inlines the contents of the GMSA credential spec named by
-                        the GMSACredentialSpecName field. This field is alpha-level
-                        and is only honored by servers that enable the WindowsGMSA
-                        feature flag.
-                      type: string
-                    gmsaCredentialSpecName:
-                      description: GMSACredentialSpecName is the name of the GMSA
-                        credential spec to use. This field is alpha-level and is only
-                        honored by servers that enable the WindowsGMSA feature flag.
-                      type: string
-                    runAsUserName:
-                      description: The UserName in Windows to run the entrypoint of
-                        the container process. Defaults to the user specified in image
-                        metadata if unspecified. May also be set in PodSecurityContext.
-                        If set in both SecurityContext and PodSecurityContext, the
-                        value specified in SecurityContext takes precedence. This
-                        field is alpha-level and it is only honored by servers that
-                        enable the WindowsRunAsUserName feature flag.
-                      type: string
-                  type: object
-              type: object
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
                 use to run the Prometheus Pods.
@@ -2959,7 +1839,6 @@ spec:
                         Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                       type: string
                     sizeLimit: {}
-                  type: object
                 volumeClaimTemplate:
                   description: PersistentVolumeClaim is a user's request for and claim
                     to a persistent volume
@@ -2968,13 +1847,13 @@ spec:
                       description: 'APIVersion defines the versioned schema of this
                         representation of an object. Servers should convert recognized
                         schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
                       type: string
                     kind:
                       description: 'Kind is a string value representing the REST resource
                         this object represents. Servers may infer this from the endpoint
                         the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                       type: string
                     metadata:
                       description: ObjectMeta is metadata that all persisted resources
@@ -3027,75 +1906,183 @@ spec:
                         generateName:
                           description: |-
                             GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-
                             If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
-
-                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                           type: string
                         generation:
                           description: A sequence number representing a specific generation
                             of the desired state. Populated by the system. Read-only.
                           format: int64
                           type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                          required:
+                          - pending
                         labels:
                           description: 'Map of string keys and values that can be
                             used to organize and categorize (scope and select) objects.
                             May match selectors of replication controllers and services.
                             More info: http://kubernetes.io/docs/user-guide/labels'
                           type: object
-                        managedFields:
-                          description: ManagedFields maps workflow-id and version
-                            to the set of fields that are managed by that workflow.
-                            This is mostly for internal housekeeping, and users typically
-                            shouldn't need to set or understand this field. A workflow
-                            can be the user's name, a controller's name, or the name
-                            of a specific apply path like "ci-cd". The set of fields
-                            is always in the version that the workflow used when modifying
-                            the object.
-                          items:
-                            description: ManagedFieldsEntry is a workflow-id, a FieldSet
-                              and the group version of the resource that the fieldset
-                              applies to.
-                            properties:
-                              apiVersion:
-                                description: APIVersion defines the version of this
-                                  resource that this field set applies to. The format
-                                  is "group/version" just like the top-level APIVersion
-                                  field. It is necessary to track the version of a
-                                  field set because it cannot be automatically converted.
-                                type: string
-                              fieldsType:
-                                description: 'FieldsType is the discriminator for
-                                  the different fields format and version. There is
-                                  currently only one possible value: "FieldsV1"'
-                                type: string
-                              fieldsV1:
-                                description: |-
-                                  FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
-
-                                  Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
-
-                                  The exact format is defined in sigs.k8s.io/structured-merge-diff
-                                type: object
-                              manager:
-                                description: Manager is an identifier of the workflow
-                                  managing these fields.
-                                type: string
-                              operation:
-                                description: Operation is the type of operation which
-                                  lead to this ManagedFieldsEntry being created. The
-                                  only valid values for this field are 'Apply' and
-                                  'Update'.
-                                type: string
-                              time:
-                                description: Time is a wrapper around time.Time which
-                                  supports correct marshaling to YAML and JSON.  Wrappers
-                                  are provided for many of the factory methods that
-                                  the time package offers.
-                                format: date-time
-                                type: string
-                            type: object
-                          type: array
                         name:
                           description: 'Name must be unique within a namespace. Is
                             required when creating resources, although some resources
@@ -3107,7 +2094,6 @@ spec:
                         namespace:
                           description: |-
                             Namespace defines the space within each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-
                             Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
                           type: string
                         ownerReferences:
@@ -3139,7 +2125,7 @@ spec:
                                   managing controller.
                                 type: boolean
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                                 type: string
                               name:
                                 description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -3152,27 +2138,21 @@ spec:
                             - kind
                             - name
                             - uid
-                            type: object
                           type: array
                         resourceVersion:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-
-                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                           type: string
                         selfLink:
-                          description: |-
-                            SelfLink is a URL representing this object. Populated by the system. Read-only.
-
-                            DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
                           type: string
                         uid:
                           description: |-
                             UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-
                             Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
                           type: string
-                      type: object
                     spec:
                       description: PersistentVolumeClaimSpec describes the common
                         attributes of storage devices and allows a Source for provider-specific
@@ -3204,7 +2184,6 @@ spec:
                           required:
                           - kind
                           - name
-                          type: object
                         resources:
                           description: ResourceRequirements describes the compute
                             resource requirements.
@@ -3220,7 +2199,6 @@ spec:
                                 explicitly specified, otherwise to an implementation-defined
                                 value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
-                          type: object
                         selector:
                           description: A label selector is a label query over a set
                             of resources. The result of matchLabels and matchExpressions
@@ -3257,7 +2235,6 @@ spec:
                                 required:
                                 - key
                                 - operator
-                                type: object
                               type: array
                             matchLabels:
                               description: matchLabels is a map of {key,value} pairs.
@@ -3266,7 +2243,6 @@ spec:
                                 is "key", the operator is "In", and the values array
                                 contains only "value". The requirements are ANDed.
                               type: object
-                          type: object
                         storageClassName:
                           description: 'Name of the StorageClass required by the claim.
                             More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
@@ -3280,7 +2256,6 @@ spec:
                           description: VolumeName is the binding reference to the
                             PersistentVolume backing this claim.
                           type: string
-                      type: object
                     status:
                       description: PersistentVolumeClaimStatus is the current status
                         of a persistent volume claim.
@@ -3335,14 +2310,10 @@ spec:
                             required:
                             - type
                             - status
-                            type: object
                           type: array
                         phase:
                           description: Phase represents the current phase of PersistentVolumeClaim.
                           type: string
-                      type: object
-                  type: object
-              type: object
             tag:
               description: Tag of Alertmanager container image to be deployed. Defaults
                 to the value of `version`. Version is ignored if Tag is set.
@@ -3385,1205 +2356,10 @@ spec:
                       If the operator is Exists, the value should be empty, otherwise
                       just a regular string.
                     type: string
-                type: object
               type: array
             version:
               description: Version the cluster should be on.
               type: string
-            volumeMounts:
-              description: VolumeMounts allows configuration of additional VolumeMounts
-                on the output StatefulSet definition. VolumeMounts specified will
-                be appended to other VolumeMounts in the alertmanager container, that
-                are generated as a result of StorageSpec objects.
-              items:
-                description: VolumeMount describes a mounting of a Volume within a
-                  container.
-                properties:
-                  mountPath:
-                    description: Path within the container at which the volume should
-                      be mounted.  Must not contain ':'.
-                    type: string
-                  mountPropagation:
-                    description: mountPropagation determines how mounts are propagated
-                      from the host to container and the other way around. When not
-                      set, MountPropagationNone is used. This field is beta in 1.10.
-                    type: string
-                  name:
-                    description: This must match the Name of a Volume.
-                    type: string
-                  readOnly:
-                    description: Mounted read-only if true, read-write otherwise (false
-                      or unspecified). Defaults to false.
-                    type: boolean
-                  subPath:
-                    description: Path within the volume from which the container's
-                      volume should be mounted. Defaults to "" (volume's root).
-                    type: string
-                  subPathExpr:
-                    description: Expanded path within the volume from which the container's
-                      volume should be mounted. Behaves similarly to SubPath but environment
-                      variable references $(VAR_NAME) are expanded using the container's
-                      environment. Defaults to "" (volume's root). SubPathExpr and
-                      SubPath are mutually exclusive. This field is beta in 1.15.
-                    type: string
-                required:
-                - name
-                - mountPath
-                type: object
-              type: array
-            volumes:
-              description: Volumes allows configuration of additional volumes on the
-                output StatefulSet definition. Volumes specified will be appended
-                to other volumes that are generated as a result of StorageSpec objects.
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: |-
-                      Represents a Persistent Disk resource in AWS.
-
-                      An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: Represents a Ceph Filesystem mount that lasts the
-                      lifetime of a pod Cephfs volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: Represents a cinder volume resource in Openstack.
-                      A Cinder volume must exist before mounting to a container. The
-                      volume must also be in the same region as the kubelet. Cinder
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: |-
-                      Adapts a ConfigMap into a volume.
-
-                      The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: Represents a source location of a volume to mount,
-                      managed by an external CSI driver
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPIVolumeSource represents a volume containing
-                      downward API info. Downward API volumes support ownership management
-                      and SELinux relabeling.
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: ObjectFieldSelector selects an APIVersioned
-                                field of an object.
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: ResourceFieldSelector represents container
-                                resources (cpu, memory) and their output format
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor: {}
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: Represents an empty directory for a pod. Empty directory
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit: {}
-                    type: object
-                  fc:
-                    description: Represents a Fibre Channel volume. Fibre Channel
-                      volumes can only be mounted as read/write once. Fibre Channel
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Represents a Flocker volume mounted by the Flocker
-                      agent. One and only one of datasetName and datasetUUID should
-                      be set. Flocker volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: |-
-                      Represents a Persistent Disk resource in Google Compute Engine.
-
-                      A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: |-
-                      Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
-
-                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: Represents a Glusterfs mount that lasts the lifetime
-                      of a pod. Glusterfs volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: Represents a host path mapped into a pod. Host path
-                      volumes do not support ownership management or SELinux relabeling.
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: Represents an ISCSI disk. ISCSI volumes can only
-                      be mounted as read/write once. ISCSI volumes support ownership
-                      management and SELinux relabeling.
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - targetPortal
-                    - iqn
-                    - lun
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: Represents an NFS mount that lasts the lifetime of
-                      a pod. NFS volumes do not support ownership management or SELinux
-                      relabeling.
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - server
-                    - path
-                    type: object
-                  persistentVolumeClaim:
-                    description: PersistentVolumeClaimVolumeSource references the
-                      user's PVC in the same namespace. This volume finds the bound
-                      PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
-                      is, essentially, a wrapper around another type of volume that
-                      is owned by someone else (the system).
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: Represents a Photon Controller persistent disk resource.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolumeSource represents a Portworx volume
-                      resource.
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Represents a projected volume source
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: |-
-                                Adapts a ConfigMap into a projected volume.
-
-                                The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: Represents downward API info for projecting
-                                into a projected volume. Note that this is identical
-                                to a downwardAPI volume source without the default
-                                mode.
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: ObjectFieldSelector selects an
-                                          APIVersioned field of an object.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: ResourceFieldSelector represents
-                                          container resources (cpu, memory) and their
-                                          output format
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor: {}
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: |-
-                                Adapts a secret into a projected volume.
-
-                                The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: ServiceAccountTokenProjection represents
-                                a projected service account token volume. This projection
-                                can be used to insert a service account token into
-                                the pods runtime filesystem for use against APIs (Kubernetes
-                                API Server or otherwise).
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Represents a Quobyte mount that lasts the lifetime
-                      of a pod. Quobyte volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: Represents a Rados Block Device mount that lasts
-                      the lifetime of a pod. RBD volumes support ownership management
-                      and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    - image
-                    type: object
-                  scaleIO:
-                    description: ScaleIOVolumeSource represents a persistent ScaleIO
-                      volume
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - system
-                    - secretRef
-                    type: object
-                  secret:
-                    description: |-
-                      Adapts a Secret into a volume.
-
-                      The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: Represents a StorageOS persistent volume resource.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: Represents a vSphere volume resource.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-          type: object
         status:
           description: 'AlertmanagerStatus is the most recent observed status of the
             Alertmanager cluster. Read-only. Not included when requesting from the
@@ -4619,8 +2395,6 @@ spec:
           - updatedReplicas
           - availableReplicas
           - unavailableReplicas
-          type: object
-      type: object
   version: v1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -4628,6 +2402,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: podmonitors.monitoring.coreos.com
+  labels:
+    app: prometheus-operator
 spec:
   group: monitoring.coreos.com
   names:
@@ -4640,12 +2416,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
           description: PodMonitorSpec contains specification parameters for a PodMonitor.
@@ -4864,6 +2640,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
+  labels:
+    app: prometheus-operator
 spec:
   group: monitoring.coreos.com
   names:
@@ -4876,16 +2654,16 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
           description: 'PrometheusSpec is a specification of the desired behavior
-            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            of the Prometheus cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
             additionalAlertManagerConfigs:
               description: SecretKeySelector selects a key of a Secret.
@@ -4898,7 +2676,7 @@ spec:
                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                   type: string
                 optional:
-                  description: Specify whether the Secret or its key must be defined
+                  description: Specify whether the Secret or it's key must be defined
                   type: boolean
               required:
               - key
@@ -4914,7 +2692,7 @@ spec:
                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                   type: string
                 optional:
-                  description: Specify whether the Secret or its key must be defined
+                  description: Specify whether the Secret or it's key must be defined
                   type: boolean
               required:
               - key
@@ -4930,7 +2708,7 @@ spec:
                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                   type: string
                 optional:
-                  description: Specify whether the Secret or its key must be defined
+                  description: Specify whether the Secret or it's key must be defined
                   type: boolean
               required:
               - key
@@ -5554,40 +3332,18 @@ spec:
                       tlsConfig:
                         description: TLSConfig specifies TLS configuration parameters.
                         properties:
-                          ca: {}
                           caFile:
-                            description: Path to the CA cert in the Prometheus container
-                              to use for the targets.
+                            description: The CA cert to use for the targets.
                             type: string
-                          cert: {}
                           certFile:
-                            description: Path to the client cert file in the Prometheus
-                              container for the targets.
+                            description: The client cert file for the targets.
                             type: string
                           insecureSkipVerify:
                             description: Disable target certificate validation.
                             type: boolean
                           keyFile:
-                            description: Path to the client key file in the Prometheus
-                              container for the targets.
+                            description: The client key file for the targets.
                             type: string
-                          keySecret:
-                            description: SecretKeySelector selects a key of a Secret.
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                            - key
-                            type: object
                           serverName:
                             description: Used to verify the hostname for the targets.
                             type: string
@@ -5620,7 +3376,7 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description: Specify whether the Secret or it's key must
                             be defined
                           type: boolean
                       required:
@@ -5637,7 +3393,7 @@ spec:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
                         optional:
-                          description: Specify whether the Secret or its key must
+                          description: Specify whether the Secret or it's key must
                             be defined
                           type: boolean
                       required:
@@ -5657,40 +3413,18 @@ spec:
                 tlsConfig:
                   description: TLSConfig specifies TLS configuration parameters.
                   properties:
-                    ca: {}
                     caFile:
-                      description: Path to the CA cert in the Prometheus container
-                        to use for the targets.
+                      description: The CA cert to use for the targets.
                       type: string
-                    cert: {}
                     certFile:
-                      description: Path to the client cert file in the Prometheus
-                        container for the targets.
+                      description: The client cert file for the targets.
                       type: string
                     insecureSkipVerify:
                       description: Disable target certificate validation.
                       type: boolean
                     keyFile:
-                      description: Path to the client key file in the Prometheus container
-                        for the targets.
+                      description: The client key file for the targets.
                       type: string
-                    keySecret:
-                      description: SecretKeySelector selects a key of a Secret.
-                      properties:
-                        key:
-                          description: The key of the secret to select from.  Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                          type: string
-                        optional:
-                          description: Specify whether the Secret or its key must
-                            be defined
-                          type: boolean
-                      required:
-                      - key
-                      type: object
                     serverName:
                       description: Used to verify the hostname for the targets.
                       type: string
@@ -5698,7 +3432,6 @@ spec:
               required:
               - host
               type: object
-            arbitraryFSAccessThroughSMs: {}
             baseImage:
               description: Base image to use for a Prometheus deployment.
               type: string
@@ -5783,7 +3516,7 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
+                                  description: Specify whether the ConfigMap or it's
                                     key must be defined
                                   type: boolean
                               required:
@@ -5830,8 +3563,8 @@ spec:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
                                 optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
+                                  description: Specify whether the Secret or it's
+                                    key must be defined
                                   type: boolean
                               required:
                               - key
@@ -6141,8 +3874,7 @@ spec:
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          1. Must be 1 for liveness. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -6294,8 +4026,7 @@ spec:
                       successThreshold:
                         description: Minimum consecutive successes for the probe to
                           be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
+                          1. Must be 1 for liveness. Minimum value is 1.
                         format: int32
                         type: integer
                       tcpSocket:
@@ -6426,142 +4157,6 @@ spec:
                               to the container.
                             type: string
                         type: object
-                      windowsOptions:
-                        description: WindowsSecurityContextOptions contain Windows-specific
-                          options and credentials.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. This field is alpha-level and it is
-                              only honored by servers that enable the WindowsRunAsUserName
-                              feature flag.
-                            type: string
-                        type: object
-                    type: object
-                  startupProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
                     type: object
                   stdin:
                     description: Whether this container should allocate a buffer for
@@ -6656,7 +4251,7 @@ spec:
                             to SubPath but environment variable references $(VAR_NAME)
                             are expanded using the container's environment. Defaults
                             to "" (volume's root). SubPathExpr and SubPath are mutually
-                            exclusive. This field is beta in 1.15.
+                            exclusive. This field is alpha in 1.14.
                           type: string
                       required:
                       - name
@@ -6709,968 +4304,6 @@ spec:
                   name:
                     description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                type: object
-              type: array
-            initContainers:
-              description: 'InitContainers allows adding initContainers to the pod
-                definition. Those can be used to e.g. fetch secrets for injection
-                into the Prometheus configuration from external sources. Any errors
-                during the execution of an initContainer will lead to a restart of
-                the Pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
-                Using initContainers for any use case other then secret fetching is
-                entirely outside the scope of what the maintainers will support and
-                by doing so, you accept that this behaviour may break at any time
-                without notice.'
-              items:
-                description: A single application container that you want to run within
-                  a pod.
-                properties:
-                  args:
-                    description: 'Arguments to the entrypoint. The docker image''s
-                      CMD is used if this is not provided. Variable references $(VAR_NAME)
-                      are expanded using the container''s environment. If a variable
-                      cannot be resolved, the reference in the input string will be
-                      unchanged. The $(VAR_NAME) syntax can be escaped with a double
-                      $$, ie: $$(VAR_NAME). Escaped references will never be expanded,
-                      regardless of whether the variable exists or not. Cannot be
-                      updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                    items:
-                      type: string
-                    type: array
-                  command:
-                    description: 'Entrypoint array. Not executed within a shell. The
-                      docker image''s ENTRYPOINT is used if this is not provided.
-                      Variable references $(VAR_NAME) are expanded using the container''s
-                      environment. If a variable cannot be resolved, the reference
-                      in the input string will be unchanged. The $(VAR_NAME) syntax
-                      can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                      will never be expanded, regardless of whether the variable exists
-                      or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
-                    items:
-                      type: string
-                    type: array
-                  env:
-                    description: List of environment variables to set in the container.
-                      Cannot be updated.
-                    items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
-                      properties:
-                        name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
-                          type: string
-                        value:
-                          description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                          type: string
-                        valueFrom:
-                          description: EnvVarSource represents a source for the value
-                            of an EnvVar.
-                          properties:
-                            configMapKeyRef:
-                              description: Selects a key from a ConfigMap.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                            fieldRef:
-                              description: ObjectFieldSelector selects an APIVersioned
-                                field of an object.
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            resourceFieldRef:
-                              description: ResourceFieldSelector represents container
-                                resources (cpu, memory) and their output format
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor: {}
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                            secretKeyRef:
-                              description: SecretKeySelector selects a key of a Secret.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  envFrom:
-                    description: List of sources to populate environment variables
-                      in the container. The keys defined within a source must be a
-                      C_IDENTIFIER. All invalid keys will be reported as an event
-                      when the container is starting. When a key exists in multiple
-                      sources, the value associated with the last source will take
-                      precedence. Values defined by an Env with a duplicate key will
-                      take precedence. Cannot be updated.
-                    items:
-                      description: EnvFromSource represents the source of a set of
-                        ConfigMaps
-                      properties:
-                        configMapRef:
-                          description: |-
-                            ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.
-
-                            The contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap must be defined
-                              type: boolean
-                          type: object
-                        prefix:
-                          description: An optional identifier to prepend to each key
-                            in the ConfigMap. Must be a C_IDENTIFIER.
-                          type: string
-                        secretRef:
-                          description: |-
-                            SecretEnvSource selects a Secret to populate the environment variables with.
-
-                            The contents of the target Secret's Data field will represent the key-value pairs as environment variables.
-                          properties:
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                              type: string
-                            optional:
-                              description: Specify whether the Secret must be defined
-                              type: boolean
-                          type: object
-                      type: object
-                    type: array
-                  image:
-                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                      This field is optional to allow higher level config management
-                      to default or override container images in workload controllers
-                      like Deployments and StatefulSets.'
-                    type: string
-                  imagePullPolicy:
-                    description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                      Defaults to Always if :latest tag is specified, or IfNotPresent
-                      otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
-                    type: string
-                  lifecycle:
-                    description: Lifecycle describes actions that the management system
-                      should take in response to container lifecycle events. For the
-                      PostStart and PreStop lifecycle handlers, management of the
-                      container blocks until the action is complete, unless the container
-                      process fails, in which case the handler is aborted.
-                    properties:
-                      postStart:
-                        description: Handler defines a specific action that should
-                          be taken
-                        properties:
-                          exec:
-                            description: ExecAction describes a "run in container"
-                              action.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          httpGet:
-                            description: HTTPGetAction describes an action based on
-                              HTTP Get requests.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          tcpSocket:
-                            description: TCPSocketAction describes an action based
-                              on opening a socket
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                        type: object
-                      preStop:
-                        description: Handler defines a specific action that should
-                          be taken
-                        properties:
-                          exec:
-                            description: ExecAction describes a "run in container"
-                              action.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          httpGet:
-                            description: HTTPGetAction describes an action based on
-                              HTTP Get requests.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          tcpSocket:
-                            description: TCPSocketAction describes an action based
-                              on opening a socket
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                - type: string
-                                - type: integer
-                            required:
-                            - port
-                            type: object
-                        type: object
-                    type: object
-                  livenessProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  name:
-                    description: Name of the container specified as a DNS_LABEL. Each
-                      container in a pod must have a unique name (DNS_LABEL). Cannot
-                      be updated.
-                    type: string
-                  ports:
-                    description: List of ports to expose from the container. Exposing
-                      a port here gives the system additional information about the
-                      network connections a container uses, but is primarily informational.
-                      Not specifying a port here DOES NOT prevent that port from being
-                      exposed. Any port which is listening on the default "0.0.0.0"
-                      address inside a container will be accessible from the network.
-                      Cannot be updated.
-                    items:
-                      description: ContainerPort represents a network port in a single
-                        container.
-                      properties:
-                        containerPort:
-                          description: Number of port to expose on the pod's IP address.
-                            This must be a valid port number, 0 < x < 65536.
-                          format: int32
-                          type: integer
-                        hostIP:
-                          description: What host IP to bind the external port to.
-                          type: string
-                        hostPort:
-                          description: Number of port to expose on the host. If specified,
-                            this must be a valid port number, 0 < x < 65536. If HostNetwork
-                            is specified, this must match ContainerPort. Most containers
-                            do not need this.
-                          format: int32
-                          type: integer
-                        name:
-                          description: If specified, this must be an IANA_SVC_NAME
-                            and unique within the pod. Each named port in a pod must
-                            have a unique name. Name for the port that can be referred
-                            to by services.
-                          type: string
-                        protocol:
-                          description: Protocol for port. Must be UDP, TCP, or SCTP.
-                            Defaults to "TCP".
-                          type: string
-                      required:
-                      - containerPort
-                      type: object
-                    type: array
-                  readinessProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  resources:
-                    description: ResourceRequirements describes the compute resource
-                      requirements.
-                    properties:
-                      limits:
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                  securityContext:
-                    description: SecurityContext holds security configuration that
-                      will be applied to a container. Some fields are present in both
-                      SecurityContext and PodSecurityContext.  When both are set,
-                      the values in SecurityContext take precedence.
-                    properties:
-                      allowPrivilegeEscalation:
-                        description: 'AllowPrivilegeEscalation controls whether a
-                          process can gain more privileges than its parent process.
-                          This bool directly controls if the no_new_privs flag will
-                          be set on the container process. AllowPrivilegeEscalation
-                          is true always when the container is: 1) run as Privileged
-                          2) has CAP_SYS_ADMIN'
-                        type: boolean
-                      capabilities:
-                        description: Adds and removes POSIX capabilities from running
-                          containers.
-                        properties:
-                          add:
-                            description: Added capabilities
-                            items:
-                              type: string
-                            type: array
-                          drop:
-                            description: Removed capabilities
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      privileged:
-                        description: Run container in privileged mode. Processes in
-                          privileged containers are essentially equivalent to root
-                          on the host. Defaults to false.
-                        type: boolean
-                      procMount:
-                        description: procMount denotes the type of proc mount to use
-                          for the containers. The default is DefaultProcMount which
-                          uses the container runtime defaults for readonly paths and
-                          masked paths. This requires the ProcMountType feature flag
-                          to be enabled.
-                        type: string
-                      readOnlyRootFilesystem:
-                        description: Whether this container has a read-only root filesystem.
-                          Default is false.
-                        type: boolean
-                      runAsGroup:
-                        description: The GID to run the entrypoint of the container
-                          process. Uses runtime default if unset. May also be set
-                          in PodSecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        description: Indicates that the container must run as a non-root
-                          user. If true, the Kubelet will validate the image at runtime
-                          to ensure that it does not run as UID 0 (root) and fail
-                          to start the container if it does. If unset or false, no
-                          such validation will be performed. May also be set in PodSecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        type: boolean
-                      runAsUser:
-                        description: The UID to run the entrypoint of the container
-                          process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in PodSecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        description: SELinuxOptions are the labels to be applied to
-                          the container
-                        properties:
-                          level:
-                            description: Level is SELinux level label that applies
-                              to the container.
-                            type: string
-                          role:
-                            description: Role is a SELinux role label that applies
-                              to the container.
-                            type: string
-                          type:
-                            description: Type is a SELinux type label that applies
-                              to the container.
-                            type: string
-                          user:
-                            description: User is a SELinux user label that applies
-                              to the container.
-                            type: string
-                        type: object
-                      windowsOptions:
-                        description: WindowsSecurityContextOptions contain Windows-specific
-                          options and credentials.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use. This field is alpha-level
-                              and is only honored by servers that enable the WindowsGMSA
-                              feature flag.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. This field is alpha-level and it is
-                              only honored by servers that enable the WindowsRunAsUserName
-                              feature flag.
-                            type: string
-                        type: object
-                    type: object
-                  startupProbe:
-                    description: Probe describes a health check to be performed against
-                      a container to determine whether it is alive or ready to receive
-                      traffic.
-                    properties:
-                      exec:
-                        description: ExecAction describes a "run in container" action.
-                        properties:
-                          command:
-                            description: Command is the command line to execute inside
-                              the container, the working directory for the command  is
-                              root ('/') in the container's filesystem. The command
-                              is simply exec'd, it is not run inside a shell, so traditional
-                              shell instructions ('|', etc) won't work. To use a shell,
-                              you need to explicitly call out to that shell. Exit
-                              status of 0 is treated as live/healthy and non-zero
-                              is unhealthy.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      failureThreshold:
-                        description: Minimum consecutive failures for the probe to
-                          be considered failed after having succeeded. Defaults to
-                          3. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      httpGet:
-                        description: HTTPGetAction describes an action based on HTTP
-                          Get requests.
-                        properties:
-                          host:
-                            description: Host name to connect to, defaults to the
-                              pod IP. You probably want to set "Host" in httpHeaders
-                              instead.
-                            type: string
-                          httpHeaders:
-                            description: Custom headers to set in the request. HTTP
-                              allows repeated headers.
-                            items:
-                              description: HTTPHeader describes a custom header to
-                                be used in HTTP probes
-                              properties:
-                                name:
-                                  description: The header field name
-                                  type: string
-                                value:
-                                  description: The header field value
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          path:
-                            description: Path to access on the HTTP server.
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                          scheme:
-                            description: Scheme to use for connecting to the host.
-                              Defaults to HTTP.
-                            type: string
-                        required:
-                        - port
-                        type: object
-                      initialDelaySeconds:
-                        description: 'Number of seconds after the container has started
-                          before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                      periodSeconds:
-                        description: How often (in seconds) to perform the probe.
-                          Default to 10 seconds. Minimum value is 1.
-                        format: int32
-                        type: integer
-                      successThreshold:
-                        description: Minimum consecutive successes for the probe to
-                          be considered successful after having failed. Defaults to
-                          1. Must be 1 for liveness and startup. Minimum value is
-                          1.
-                        format: int32
-                        type: integer
-                      tcpSocket:
-                        description: TCPSocketAction describes an action based on
-                          opening a socket
-                        properties:
-                          host:
-                            description: 'Optional: Host name to connect to, defaults
-                              to the pod IP.'
-                            type: string
-                          port:
-                            anyOf:
-                            - type: string
-                            - type: integer
-                        required:
-                        - port
-                        type: object
-                      timeoutSeconds:
-                        description: 'Number of seconds after which the probe times
-                          out. Defaults to 1 second. Minimum value is 1. More info:
-                          https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        format: int32
-                        type: integer
-                    type: object
-                  stdin:
-                    description: Whether this container should allocate a buffer for
-                      stdin in the container runtime. If this is not set, reads from
-                      stdin in the container will always result in EOF. Default is
-                      false.
-                    type: boolean
-                  stdinOnce:
-                    description: Whether the container runtime should close the stdin
-                      channel after it has been opened by a single attach. When stdin
-                      is true the stdin stream will remain open across multiple attach
-                      sessions. If stdinOnce is set to true, stdin is opened on container
-                      start, is empty until the first client attaches to stdin, and
-                      then remains open and accepts data until the client disconnects,
-                      at which time stdin is closed and remains closed until the container
-                      is restarted. If this flag is false, a container processes that
-                      reads from stdin will never receive an EOF. Default is false
-                    type: boolean
-                  terminationMessagePath:
-                    description: 'Optional: Path at which the file to which the container''s
-                      termination message will be written is mounted into the container''s
-                      filesystem. Message written is intended to be brief final status,
-                      such as an assertion failure message. Will be truncated by the
-                      node if greater than 4096 bytes. The total message length across
-                      all containers will be limited to 12kb. Defaults to /dev/termination-log.
-                      Cannot be updated.'
-                    type: string
-                  terminationMessagePolicy:
-                    description: Indicate how the termination message should be populated.
-                      File will use the contents of terminationMessagePath to populate
-                      the container status message on both success and failure. FallbackToLogsOnError
-                      will use the last chunk of container log output if the termination
-                      message file is empty and the container exited with an error.
-                      The log output is limited to 2048 bytes or 80 lines, whichever
-                      is smaller. Defaults to File. Cannot be updated.
-                    type: string
-                  tty:
-                    description: Whether this container should allocate a TTY for
-                      itself, also requires 'stdin' to be true. Default is false.
-                    type: boolean
-                  volumeDevices:
-                    description: volumeDevices is the list of block devices to be
-                      used by the container. This is a beta feature.
-                    items:
-                      description: volumeDevice describes a mapping of a raw block
-                        device within a container.
-                      properties:
-                        devicePath:
-                          description: devicePath is the path inside of the container
-                            that the device will be mapped to.
-                          type: string
-                        name:
-                          description: name must match the name of a persistentVolumeClaim
-                            in the pod
-                          type: string
-                      required:
-                      - name
-                      - devicePath
-                      type: object
-                    type: array
-                  volumeMounts:
-                    description: Pod volumes to mount into the container's filesystem.
-                      Cannot be updated.
-                    items:
-                      description: VolumeMount describes a mounting of a Volume within
-                        a container.
-                      properties:
-                        mountPath:
-                          description: Path within the container at which the volume
-                            should be mounted.  Must not contain ':'.
-                          type: string
-                        mountPropagation:
-                          description: mountPropagation determines how mounts are
-                            propagated from the host to container and the other way
-                            around. When not set, MountPropagationNone is used. This
-                            field is beta in 1.10.
-                          type: string
-                        name:
-                          description: This must match the Name of a Volume.
-                          type: string
-                        readOnly:
-                          description: Mounted read-only if true, read-write otherwise
-                            (false or unspecified). Defaults to false.
-                          type: boolean
-                        subPath:
-                          description: Path within the volume from which the container's
-                            volume should be mounted. Defaults to "" (volume's root).
-                          type: string
-                        subPathExpr:
-                          description: Expanded path within the volume from which
-                            the container's volume should be mounted. Behaves similarly
-                            to SubPath but environment variable references $(VAR_NAME)
-                            are expanded using the container's environment. Defaults
-                            to "" (volume's root). SubPathExpr and SubPath are mutually
-                            exclusive. This field is beta in 1.15.
-                          type: string
-                      required:
-                      - name
-                      - mountPath
-                      type: object
-                    type: array
-                  workingDir:
-                    description: Container's working directory. If not specified,
-                      the container runtime's default will be used, which might be
-                      configured in the container image. Cannot be updated.
-                    type: string
-                required:
-                - name
                 type: object
               type: array
             listenLocal:
@@ -7739,13 +4372,172 @@ spec:
 
                     If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
 
-                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                    Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                   type: string
                 generation:
                   description: A sequence number representing a specific generation
                     of the desired state. Populated by the system. Read-only.
                   format: int64
                   type: integer
+                initializers:
+                  description: Initializers tracks the progress of initialization.
+                  properties:
+                    pending:
+                      description: Pending is a list of initializers that must execute
+                        in order before this object is visible. When the last pending
+                        initializer is removed, and no failing result is set, the
+                        initializers struct will be set to nil and the object is considered
+                        as initialized and visible to all clients.
+                      items:
+                        description: Initializer is information about an initializer
+                          that has not yet completed.
+                        properties:
+                          name:
+                            description: name of the process that is responsible for
+                              initializing this object.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    result:
+                      description: Status is a return value for calls that don't return
+                        other objects.
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                          type: string
+                        code:
+                          description: Suggested HTTP return code for this status,
+                            0 if not set.
+                          format: int32
+                          type: integer
+                        details:
+                          description: StatusDetails is a set of additional properties
+                            that MAY be set by the server to provide additional information
+                            about a response. The Reason field of a Status object
+                            defines what attributes will be set. Clients must ignore
+                            fields that do not match the defined type of each attribute,
+                            and should assume that any attribute may be empty, invalid,
+                            or under defined.
+                          properties:
+                            causes:
+                              description: The Causes array includes more details
+                                associated with the StatusReason failure. Not all
+                                StatusReasons may provide detailed causes.
+                              items:
+                                description: StatusCause provides more information
+                                  about an api.Status failure, including cases when
+                                  multiple errors are encountered.
+                                properties:
+                                  field:
+                                    description: |-
+                                      The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                      Examples:
+                                        "name" - the field "name" on the current resource
+                                        "items[0].name" - the field "name" on the first array entry in "items"
+                                    type: string
+                                  message:
+                                    description: A human-readable description of the
+                                      cause of the error.  This field may be presented
+                                      as-is to a reader.
+                                    type: string
+                                  reason:
+                                    description: A machine-readable description of
+                                      the cause of the error. If this value is empty
+                                      there is no information available.
+                                    type: string
+                                type: object
+                              type: array
+                            group:
+                              description: The group attribute of the resource associated
+                                with the status StatusReason.
+                              type: string
+                            kind:
+                              description: 'The kind attribute of the resource associated
+                                with the status StatusReason. On some operations may
+                                differ from the requested resource Kind. More info:
+                                https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: The name attribute of the resource associated
+                                with the status StatusReason (when there is a single
+                                name which can be described).
+                              type: string
+                            retryAfterSeconds:
+                              description: If specified, the time in seconds before
+                                the operation should be retried. Some errors may indicate
+                                the client must take an alternate action - for those
+                                errors this field may indicate how long to wait before
+                                taking the alternate action.
+                              format: int32
+                              type: integer
+                            uid:
+                              description: 'UID of the resource. (when there is a
+                                single resource which can be described). More info:
+                                http://kubernetes.io/docs/user-guide/identifiers#uids'
+                              type: string
+                          type: object
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        message:
+                          description: A human-readable description of the status
+                            of this operation.
+                          type: string
+                        metadata:
+                          description: ListMeta describes metadata that synthetic
+                            resources must have, including lists and various status
+                            objects. A resource may have only one of {ObjectMeta,
+                            ListMeta}.
+                          properties:
+                            continue:
+                              description: continue may be set if the user set a limit
+                                on the number of items returned, and indicates that
+                                the server has more data available. The value is opaque
+                                and may be used to issue another request to the endpoint
+                                that served this list to retrieve the next set of
+                                available objects. Continuing a consistent list may
+                                not be possible if the server configuration has changed
+                                or more than a few minutes have passed. The resourceVersion
+                                field returned when using this continue value will
+                                be identical to the value in the first response, unless
+                                you have received this token from an error message.
+                              type: string
+                            resourceVersion:
+                              description: 'String that identifies the server''s internal
+                                version of this object that can be used by clients
+                                to determine when objects have changed. Value must
+                                be treated as opaque by clients and passed unmodified
+                                back to the server. Populated by the system. Read-only.
+                                More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            selfLink:
+                              description: selfLink is a URL representing this object.
+                                Populated by the system. Read-only.
+                              type: string
+                          type: object
+                        reason:
+                          description: A machine-readable description of why this
+                            operation is in the "Failure" status. If this value is
+                            empty there is no information available. A Reason clarifies
+                            an HTTP status code but does not override it.
+                          type: string
+                        status:
+                          description: 'Status of the operation. One of: "Success"
+                            or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                          type: string
+                      type: object
+                  required:
+                  - pending
+                  type: object
                 labels:
                   description: 'Map of string keys and values that can be used to
                     organize and categorize (scope and select) objects. May match
@@ -7753,13 +4545,10 @@ spec:
                     http://kubernetes.io/docs/user-guide/labels'
                   type: object
                 managedFields:
-                  description: ManagedFields maps workflow-id and version to the set
-                    of fields that are managed by that workflow. This is mostly for
-                    internal housekeeping, and users typically shouldn't need to set
-                    or understand this field. A workflow can be the user's name, a
-                    controller's name, or the name of a specific apply path like "ci-cd".
-                    The set of fields is always in the version that the workflow used
-                    when modifying the object.
+                  description: |-
+                    ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                    This field is alpha and can be changed or removed without notice.
                   items:
                     description: ManagedFieldsEntry is a workflow-id, a FieldSet and
                       the group version of the resource that the fieldset applies
@@ -7772,18 +4561,9 @@ spec:
                           to track the version of a field set because it cannot be
                           automatically converted.
                         type: string
-                      fieldsType:
-                        description: 'FieldsType is the discriminator for the different
-                          fields format and version. There is currently only one possible
-                          value: "FieldsV1"'
-                        type: string
-                      fieldsV1:
-                        description: |-
-                          FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
-
-                          Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
-
-                          The exact format is defined in sigs.k8s.io/structured-merge-diff
+                      fields:
+                        description: 'Fields stores a set of fields in a data structure
+                          like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
                         type: object
                       manager:
                         description: Manager is an identifier of the workflow managing
@@ -7842,7 +4622,7 @@ spec:
                           controller.
                         type: boolean
                       kind:
-                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                         type: string
                       name:
                         description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -7861,13 +4641,11 @@ spec:
                   description: |-
                     An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
 
-                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                   type: string
                 selfLink:
-                  description: |-
-                    SelfLink is a URL representing this object. Populated by the system. Read-only.
-
-                    DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
                   type: string
                 uid:
                   description: |-
@@ -7964,10 +4742,6 @@ spec:
                     are ANDed.
                   type: object
               type: object
-            portName:
-              description: Port name used for the pods and governing service. This
-                defaults to web
-              type: string
             priorityClassName:
               description: Priority class assigned to the Pods
               type: string
@@ -8021,7 +4795,7 @@ spec:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description: Specify whether the Secret or it's key must
                               be defined
                             type: boolean
                         required:
@@ -8038,7 +4812,7 @@ spec:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description: Specify whether the Secret or it's key must
                               be defined
                             type: boolean
                         required:
@@ -8068,40 +4842,18 @@ spec:
                   tlsConfig:
                     description: TLSConfig specifies TLS configuration parameters.
                     properties:
-                      ca: {}
                       caFile:
-                        description: Path to the CA cert in the Prometheus container
-                          to use for the targets.
+                        description: The CA cert to use for the targets.
                         type: string
-                      cert: {}
                       certFile:
-                        description: Path to the client cert file in the Prometheus
-                          container for the targets.
+                        description: The client cert file for the targets.
                         type: string
                       insecureSkipVerify:
                         description: Disable target certificate validation.
                         type: boolean
                       keyFile:
-                        description: Path to the client key file in the Prometheus
-                          container for the targets.
+                        description: The client key file for the targets.
                         type: string
-                      keySecret:
-                        description: SecretKeySelector selects a key of a Secret.
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
                       serverName:
                         description: Used to verify the hostname for the targets.
                         type: string
@@ -8135,7 +4887,7 @@ spec:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description: Specify whether the Secret or it's key must
                               be defined
                             type: boolean
                         required:
@@ -8152,7 +4904,7 @@ spec:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description: Specify whether the Secret or it's key must
                               be defined
                             type: boolean
                         required:
@@ -8216,40 +4968,18 @@ spec:
                   tlsConfig:
                     description: TLSConfig specifies TLS configuration parameters.
                     properties:
-                      ca: {}
                       caFile:
-                        description: Path to the CA cert in the Prometheus container
-                          to use for the targets.
+                        description: The CA cert to use for the targets.
                         type: string
-                      cert: {}
                       certFile:
-                        description: Path to the client cert file in the Prometheus
-                          container for the targets.
+                        description: The client cert file for the targets.
                         type: string
                       insecureSkipVerify:
                         description: Disable target certificate validation.
                         type: boolean
                       keyFile:
-                        description: Path to the client key file in the Prometheus
-                          container for the targets.
+                        description: The client key file for the targets.
                         type: string
-                      keySecret:
-                        description: SecretKeySelector selects a key of a Secret.
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
                       serverName:
                         description: Used to verify the hostname for the targets.
                         type: string
@@ -8337,6 +5067,9 @@ spec:
             retentionSize:
               description: Maximum amount of disk space used by blocks.
               type: string
+            walCompression:
+              description: Enable compression of the write-ahead log using Snappy.
+              type: boolean
             routePrefix:
               description: The route prefix Prometheus registers HTTP handlers for.
                 This is useful, if using ExternalURL and a proxy is rewriting HTTP
@@ -8549,33 +5282,6 @@ spec:
                     - value
                     type: object
                   type: array
-                windowsOptions:
-                  description: WindowsSecurityContextOptions contain Windows-specific
-                    options and credentials.
-                  properties:
-                    gmsaCredentialSpec:
-                      description: GMSACredentialSpec is where the GMSA admission
-                        webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                        inlines the contents of the GMSA credential spec named by
-                        the GMSACredentialSpecName field. This field is alpha-level
-                        and is only honored by servers that enable the WindowsGMSA
-                        feature flag.
-                      type: string
-                    gmsaCredentialSpecName:
-                      description: GMSACredentialSpecName is the name of the GMSA
-                        credential spec to use. This field is alpha-level and is only
-                        honored by servers that enable the WindowsGMSA feature flag.
-                      type: string
-                    runAsUserName:
-                      description: The UserName in Windows to run the entrypoint of
-                        the container process. Defaults to the user specified in image
-                        metadata if unspecified. May also be set in PodSecurityContext.
-                        If set in both SecurityContext and PodSecurityContext, the
-                        value specified in SecurityContext takes precedence. This
-                        field is alpha-level and it is only honored by servers that
-                        enable the WindowsRunAsUserName feature flag.
-                      type: string
-                  type: object
               type: object
             serviceAccountName:
               description: ServiceAccountName is the name of the ServiceAccount to
@@ -8700,13 +5406,13 @@ spec:
                       description: 'APIVersion defines the versioned schema of this
                         representation of an object. Servers should convert recognized
                         schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
                       type: string
                     kind:
                       description: 'Kind is a string value representing the REST resource
                         this object represents. Servers may infer this from the endpoint
                         the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                       type: string
                     metadata:
                       description: ObjectMeta is metadata that all persisted resources
@@ -8762,13 +5468,183 @@ spec:
 
                             If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
 
-                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                            Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
                           type: string
                         generation:
                           description: A sequence number representing a specific generation
                             of the desired state. Populated by the system. Read-only.
                           format: int64
                           type: integer
+                        initializers:
+                          description: Initializers tracks the progress of initialization.
+                          properties:
+                            pending:
+                              description: Pending is a list of initializers that
+                                must execute in order before this object is visible.
+                                When the last pending initializer is removed, and
+                                no failing result is set, the initializers struct
+                                will be set to nil and the object is considered as
+                                initialized and visible to all clients.
+                              items:
+                                description: Initializer is information about an initializer
+                                  that has not yet completed.
+                                properties:
+                                  name:
+                                    description: name of the process that is responsible
+                                      for initializing this object.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            result:
+                              description: Status is a return value for calls that
+                                don't return other objects.
+                              properties:
+                                apiVersion:
+                                  description: 'APIVersion defines the versioned schema
+                                    of this representation of an object. Servers should
+                                    convert recognized schemas to the latest internal
+                                    value, and may reject unrecognized values. More
+                                    info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                                  type: string
+                                code:
+                                  description: Suggested HTTP return code for this
+                                    status, 0 if not set.
+                                  format: int32
+                                  type: integer
+                                details:
+                                  description: StatusDetails is a set of additional
+                                    properties that MAY be set by the server to provide
+                                    additional information about a response. The Reason
+                                    field of a Status object defines what attributes
+                                    will be set. Clients must ignore fields that do
+                                    not match the defined type of each attribute,
+                                    and should assume that any attribute may be empty,
+                                    invalid, or under defined.
+                                  properties:
+                                    causes:
+                                      description: The Causes array includes more
+                                        details associated with the StatusReason failure.
+                                        Not all StatusReasons may provide detailed
+                                        causes.
+                                      items:
+                                        description: StatusCause provides more information
+                                          about an api.Status failure, including cases
+                                          when multiple errors are encountered.
+                                        properties:
+                                          field:
+                                            description: |-
+                                              The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                              Examples:
+                                                "name" - the field "name" on the current resource
+                                                "items[0].name" - the field "name" on the first array entry in "items"
+                                            type: string
+                                          message:
+                                            description: A human-readable description
+                                              of the cause of the error.  This field
+                                              may be presented as-is to a reader.
+                                            type: string
+                                          reason:
+                                            description: A machine-readable description
+                                              of the cause of the error. If this value
+                                              is empty there is no information available.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    group:
+                                      description: The group attribute of the resource
+                                        associated with the status StatusReason.
+                                      type: string
+                                    kind:
+                                      description: 'The kind attribute of the resource
+                                        associated with the status StatusReason. On
+                                        some operations may differ from the requested
+                                        resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: The name attribute of the resource
+                                        associated with the status StatusReason (when
+                                        there is a single name which can be described).
+                                      type: string
+                                    retryAfterSeconds:
+                                      description: If specified, the time in seconds
+                                        before the operation should be retried. Some
+                                        errors may indicate the client must take an
+                                        alternate action - for those errors this field
+                                        may indicate how long to wait before taking
+                                        the alternate action.
+                                      format: int32
+                                      type: integer
+                                    uid:
+                                      description: 'UID of the resource. (when there
+                                        is a single resource which can be described).
+                                        More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                      type: string
+                                  type: object
+                                kind:
+                                  description: 'Kind is a string value representing
+                                    the REST resource this object represents. Servers
+                                    may infer this from the endpoint the client submits
+                                    requests to. Cannot be updated. In CamelCase.
+                                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                                  type: string
+                                message:
+                                  description: A human-readable description of the
+                                    status of this operation.
+                                  type: string
+                                metadata:
+                                  description: ListMeta describes metadata that synthetic
+                                    resources must have, including lists and various
+                                    status objects. A resource may have only one of
+                                    {ObjectMeta, ListMeta}.
+                                  properties:
+                                    continue:
+                                      description: continue may be set if the user
+                                        set a limit on the number of items returned,
+                                        and indicates that the server has more data
+                                        available. The value is opaque and may be
+                                        used to issue another request to the endpoint
+                                        that served this list to retrieve the next
+                                        set of available objects. Continuing a consistent
+                                        list may not be possible if the server configuration
+                                        has changed or more than a few minutes have
+                                        passed. The resourceVersion field returned
+                                        when using this continue value will be identical
+                                        to the value in the first response, unless
+                                        you have received this token from an error
+                                        message.
+                                      type: string
+                                    resourceVersion:
+                                      description: 'String that identifies the server''s
+                                        internal version of this object that can be
+                                        used by clients to determine when objects
+                                        have changed. Value must be treated as opaque
+                                        by clients and passed unmodified back to the
+                                        server. Populated by the system. Read-only.
+                                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                                      type: string
+                                    selfLink:
+                                      description: selfLink is a URL representing
+                                        this object. Populated by the system. Read-only.
+                                      type: string
+                                  type: object
+                                reason:
+                                  description: A machine-readable description of why
+                                    this operation is in the "Failure" status. If
+                                    this value is empty there is no information available.
+                                    A Reason clarifies an HTTP status code but does
+                                    not override it.
+                                  type: string
+                                status:
+                                  description: 'Status of the operation. One of: "Success"
+                                    or "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                                  type: string
+                              type: object
+                          required:
+                          - pending
+                          type: object
                         labels:
                           description: 'Map of string keys and values that can be
                             used to organize and categorize (scope and select) objects.
@@ -8776,14 +5652,10 @@ spec:
                             More info: http://kubernetes.io/docs/user-guide/labels'
                           type: object
                         managedFields:
-                          description: ManagedFields maps workflow-id and version
-                            to the set of fields that are managed by that workflow.
-                            This is mostly for internal housekeeping, and users typically
-                            shouldn't need to set or understand this field. A workflow
-                            can be the user's name, a controller's name, or the name
-                            of a specific apply path like "ci-cd". The set of fields
-                            is always in the version that the workflow used when modifying
-                            the object.
+                          description: |-
+                            ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                            This field is alpha and can be changed or removed without notice.
                           items:
                             description: ManagedFieldsEntry is a workflow-id, a FieldSet
                               and the group version of the resource that the fieldset
@@ -8796,18 +5668,10 @@ spec:
                                   field. It is necessary to track the version of a
                                   field set because it cannot be automatically converted.
                                 type: string
-                              fieldsType:
-                                description: 'FieldsType is the discriminator for
-                                  the different fields format and version. There is
-                                  currently only one possible value: "FieldsV1"'
-                                type: string
-                              fieldsV1:
-                                description: |-
-                                  FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
-
-                                  Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
-
-                                  The exact format is defined in sigs.k8s.io/structured-merge-diff
+                              fields:
+                                description: 'Fields stores a set of fields in a data
+                                  structure like a Trie. To understand how this is
+                                  used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
                                 type: object
                               manager:
                                 description: Manager is an identifier of the workflow
@@ -8871,7 +5735,7 @@ spec:
                                   managing controller.
                                 type: boolean
                               kind:
-                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                                 type: string
                               name:
                                 description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -8890,13 +5754,11 @@ spec:
                           description: |-
                             An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
 
-                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
                           type: string
                         selfLink:
-                          description: |-
-                            SelfLink is a URL representing this object. Populated by the system. Read-only.
-
-                            DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
                           type: string
                         uid:
                           description: |-
@@ -9092,10 +5954,6 @@ spec:
                     to ensure the Prometheus Operator knows what version of Thanos
                     is being configured.
                   type: string
-                listenLocal:
-                  description: ListenLocal makes the Thanos sidecar listen on loopback,
-                    so that it does not bind against the Pod IP.
-                  type: boolean
                 objectStorageConfig:
                   description: SecretKeySelector selects a key of a Secret.
                   properties:
@@ -9107,7 +5965,8 @@ spec:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
                     optional:
-                      description: Specify whether the Secret or its key must be defined
+                      description: Specify whether the Secret or it's key must be
+                        defined
                       type: boolean
                   required:
                   - key
@@ -9185,1164 +6044,6 @@ spec:
             version:
               description: Version of Prometheus to be deployed.
               type: string
-            volumes:
-              description: Volumes allows configuration of additional volumes on the
-                output StatefulSet definition. Volumes specified will be appended
-                to other volumes that are generated as a result of StorageSpec objects.
-              items:
-                description: Volume represents a named volume in a pod that may be
-                  accessed by any container in the pod.
-                properties:
-                  awsElasticBlockStore:
-                    description: |-
-                      Represents a Persistent Disk resource in AWS.
-
-                      An AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty).'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Specify "true" to force and set the ReadOnly
-                          property in VolumeMounts to "true". If omitted, the default
-                          is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: boolean
-                      volumeID:
-                        description: 'Unique ID of the persistent disk resource in
-                          AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  azureDisk:
-                    description: AzureDisk represents an Azure Data Disk mount on
-                      the host and bind mount to the pod.
-                    properties:
-                      cachingMode:
-                        description: 'Host Caching mode: None, Read Only, Read Write.'
-                        type: string
-                      diskName:
-                        description: The Name of the data disk in the blob storage
-                        type: string
-                      diskURI:
-                        description: The URI the data disk in the blob storage
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      kind:
-                        description: 'Expected values Shared: multiple blob disks
-                          per storage account  Dedicated: single blob disk per storage
-                          account  Managed: azure managed data disk (only in managed
-                          availability set). defaults to shared'
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                    required:
-                    - diskName
-                    - diskURI
-                    type: object
-                  azureFile:
-                    description: AzureFile represents an Azure File Service mount
-                      on the host and bind mount to the pod.
-                    properties:
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretName:
-                        description: the name of secret that contains Azure Storage
-                          Account Name and Key
-                        type: string
-                      shareName:
-                        description: Share Name
-                        type: string
-                    required:
-                    - secretName
-                    - shareName
-                    type: object
-                  cephfs:
-                    description: Represents a Ceph Filesystem mount that lasts the
-                      lifetime of a pod Cephfs volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      monitors:
-                        description: 'Required: Monitors is a collection of Ceph monitors
-                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      path:
-                        description: 'Optional: Used as the mounted root, rather than
-                          the full Ceph tree, default is /'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: boolean
-                      secretFile:
-                        description: 'Optional: SecretFile is the path to key ring
-                          for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      user:
-                        description: 'Optional: User is the rados user name, default
-                          is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    type: object
-                  cinder:
-                    description: Represents a cinder volume resource in Openstack.
-                      A Cinder volume must exist before mounting to a container. The
-                      volume must also be in the same region as the kubelet. Cinder
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Examples: "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts. More
-                          info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      volumeID:
-                        description: 'volume id used to identify the volume in cinder.
-                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  configMap:
-                    description: |-
-                      Adapts a ConfigMap into a volume.
-
-                      The contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced ConfigMap will be projected into
-                          the volume as a file whose name is the key and content is
-                          the value. If specified, the listed keys will be projected
-                          into the specified paths, and unlisted keys will not be
-                          present. If a key is specified which is not present in the
-                          ConfigMap, the volume setup will error unless it is marked
-                          optional. Paths must be relative and may not contain the
-                          '..' path or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      optional:
-                        description: Specify whether the ConfigMap or its keys must
-                          be defined
-                        type: boolean
-                    type: object
-                  csi:
-                    description: Represents a source location of a volume to mount,
-                      managed by an external CSI driver
-                    properties:
-                      driver:
-                        description: Driver is the name of the CSI driver that handles
-                          this volume. Consult with your admin for the correct name
-                          as registered in the cluster.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Ex. "ext4", "xfs",
-                          "ntfs". If not provided, the empty value is passed to the
-                          associated CSI driver which will determine the default filesystem
-                          to apply.
-                        type: string
-                      nodePublishSecretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      readOnly:
-                        description: Specifies a read-only configuration for the volume.
-                          Defaults to false (read/write).
-                        type: boolean
-                      volumeAttributes:
-                        description: VolumeAttributes stores driver-specific properties
-                          that are passed to the CSI driver. Consult your driver's
-                          documentation for supported values.
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  downwardAPI:
-                    description: DownwardAPIVolumeSource represents a volume containing
-                      downward API info. Downward API volumes support ownership management
-                      and SELinux relabeling.
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: Items is a list of downward API volume file
-                        items:
-                          description: DownwardAPIVolumeFile represents information
-                            to create the file containing the pod field
-                          properties:
-                            fieldRef:
-                              description: ObjectFieldSelector selects an APIVersioned
-                                field of an object.
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: 'Required: Path is  the relative path name
-                                of the file to be created. Must not be absolute or
-                                contain the ''..'' path. Must be utf-8 encoded. The
-                                first item of the relative path must not start with
-                                ''..'''
-                              type: string
-                            resourceFieldRef:
-                              description: ResourceFieldSelector represents container
-                                resources (cpu, memory) and their output format
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor: {}
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                          required:
-                          - path
-                          type: object
-                        type: array
-                    type: object
-                  emptyDir:
-                    description: Represents an empty directory for a pod. Empty directory
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      medium:
-                        description: 'What type of storage medium should back this
-                          directory. The default is "" which means to use the node''s
-                          default medium. Must be an empty string (default) or Memory.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        type: string
-                      sizeLimit: {}
-                    type: object
-                  fc:
-                    description: Represents a Fibre Channel volume. Fibre Channel
-                      volumes can only be mounted as read/write once. Fibre Channel
-                      volumes support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      lun:
-                        description: 'Optional: FC target lun number'
-                        format: int32
-                        type: integer
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      targetWWNs:
-                        description: 'Optional: FC target worldwide names (WWNs)'
-                        items:
-                          type: string
-                        type: array
-                      wwids:
-                        description: 'Optional: FC volume world wide identifiers (wwids)
-                          Either wwids or combination of targetWWNs and lun must be
-                          set, but not both simultaneously.'
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  flexVolume:
-                    description: FlexVolume represents a generic volume resource that
-                      is provisioned/attached using an exec based plugin.
-                    properties:
-                      driver:
-                        description: Driver is the name of the driver to use for this
-                          volume.
-                        type: string
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". The default filesystem depends on FlexVolume
-                          script.
-                        type: string
-                      options:
-                        description: 'Optional: Extra command options if any.'
-                        type: object
-                      readOnly:
-                        description: 'Optional: Defaults to false (read/write). ReadOnly
-                          here will force the ReadOnly setting in VolumeMounts.'
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                    required:
-                    - driver
-                    type: object
-                  flocker:
-                    description: Represents a Flocker volume mounted by the Flocker
-                      agent. One and only one of datasetName and datasetUUID should
-                      be set. Flocker volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      datasetName:
-                        description: Name of the dataset stored as metadata -> name
-                          on the dataset for Flocker should be considered as deprecated
-                        type: string
-                      datasetUUID:
-                        description: UUID of the dataset. This is unique identifier
-                          of a Flocker dataset
-                        type: string
-                    type: object
-                  gcePersistentDisk:
-                    description: |-
-                      Represents a Persistent Disk resource in Google Compute Engine.
-
-                      A GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      partition:
-                        description: 'The partition in the volume that you want to
-                          mount. If omitted, the default is to mount by volume name.
-                          Examples: For volume /dev/sda1, you specify the partition
-                          as "1". Similarly, the volume partition for /dev/sda is
-                          "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        format: int32
-                        type: integer
-                      pdName:
-                        description: 'Unique name of the PD resource in GCE. Used
-                          to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        type: boolean
-                    required:
-                    - pdName
-                    type: object
-                  gitRepo:
-                    description: |-
-                      Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.
-
-                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
-                    properties:
-                      directory:
-                        description: Target directory name. Must not contain or start
-                          with '..'.  If '.' is supplied, the volume directory will
-                          be the git repository.  Otherwise, if specified, the volume
-                          will contain the git repository in the subdirectory with
-                          the given name.
-                        type: string
-                      repository:
-                        description: Repository URL
-                        type: string
-                      revision:
-                        description: Commit hash for the specified revision.
-                        type: string
-                    required:
-                    - repository
-                    type: object
-                  glusterfs:
-                    description: Represents a Glusterfs mount that lasts the lifetime
-                      of a pod. Glusterfs volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      endpoints:
-                        description: 'EndpointsName is the endpoint name that details
-                          Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      path:
-                        description: 'Path is the Glusterfs volume path. More info:
-                          https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the Glusterfs volume
-                          to be mounted with read-only permissions. Defaults to false.
-                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                        type: boolean
-                    required:
-                    - endpoints
-                    - path
-                    type: object
-                  hostPath:
-                    description: Represents a host path mapped into a pod. Host path
-                      volumes do not support ownership management or SELinux relabeling.
-                    properties:
-                      path:
-                        description: 'Path of the directory on the host. If the path
-                          is a symlink, it will follow the link to the real path.
-                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                      type:
-                        description: 'Type for HostPath Volume Defaults to "" More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        type: string
-                    required:
-                    - path
-                    type: object
-                  iscsi:
-                    description: Represents an ISCSI disk. ISCSI volumes can only
-                      be mounted as read/write once. ISCSI volumes support ownership
-                      management and SELinux relabeling.
-                    properties:
-                      chapAuthDiscovery:
-                        description: whether support iSCSI Discovery CHAP authentication
-                        type: boolean
-                      chapAuthSession:
-                        description: whether support iSCSI Session CHAP authentication
-                        type: boolean
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
-                        type: string
-                      initiatorName:
-                        description: Custom iSCSI Initiator Name. If initiatorName
-                          is specified with iscsiInterface simultaneously, new iSCSI
-                          interface <target portal>:<volume name> will be created
-                          for the connection.
-                        type: string
-                      iqn:
-                        description: Target iSCSI Qualified Name.
-                        type: string
-                      iscsiInterface:
-                        description: iSCSI Interface Name that uses an iSCSI transport.
-                          Defaults to 'default' (tcp).
-                        type: string
-                      lun:
-                        description: iSCSI Target Lun number.
-                        format: int32
-                        type: integer
-                      portals:
-                        description: iSCSI Target Portal List. The portal is either
-                          an IP or ip_addr:port if the port is other than default
-                          (typically TCP ports 860 and 3260).
-                        items:
-                          type: string
-                        type: array
-                      readOnly:
-                        description: ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false.
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      targetPortal:
-                        description: iSCSI Target Portal. The Portal is either an
-                          IP or ip_addr:port if the port is other than default (typically
-                          TCP ports 860 and 3260).
-                        type: string
-                    required:
-                    - targetPortal
-                    - iqn
-                    - lun
-                    type: object
-                  name:
-                    description: 'Volume''s name. Must be a DNS_LABEL and unique within
-                      the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  nfs:
-                    description: Represents an NFS mount that lasts the lifetime of
-                      a pod. NFS volumes do not support ownership management or SELinux
-                      relabeling.
-                    properties:
-                      path:
-                        description: 'Path that is exported by the NFS server. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the NFS export to be
-                          mounted with read-only permissions. Defaults to false. More
-                          info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: boolean
-                      server:
-                        description: 'Server is the hostname or IP address of the
-                          NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        type: string
-                    required:
-                    - server
-                    - path
-                    type: object
-                  persistentVolumeClaim:
-                    description: PersistentVolumeClaimVolumeSource references the
-                      user's PVC in the same namespace. This volume finds the bound
-                      PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource
-                      is, essentially, a wrapper around another type of volume that
-                      is owned by someone else (the system).
-                    properties:
-                      claimName:
-                        description: 'ClaimName is the name of a PersistentVolumeClaim
-                          in the same namespace as the pod using this volume. More
-                          info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        type: string
-                      readOnly:
-                        description: Will force the ReadOnly setting in VolumeMounts.
-                          Default false.
-                        type: boolean
-                    required:
-                    - claimName
-                    type: object
-                  photonPersistentDisk:
-                    description: Represents a Photon Controller persistent disk resource.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      pdID:
-                        description: ID that identifies Photon Controller persistent
-                          disk
-                        type: string
-                    required:
-                    - pdID
-                    type: object
-                  portworxVolume:
-                    description: PortworxVolumeSource represents a Portworx volume
-                      resource.
-                    properties:
-                      fsType:
-                        description: FSType represents the filesystem type to mount
-                          Must be a filesystem type supported by the host operating
-                          system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                          if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      volumeID:
-                        description: VolumeID uniquely identifies a Portworx volume
-                        type: string
-                    required:
-                    - volumeID
-                    type: object
-                  projected:
-                    description: Represents a projected volume source
-                    properties:
-                      defaultMode:
-                        description: Mode bits to use on created files by default.
-                          Must be a value between 0 and 0777. Directories within the
-                          path are not affected by this setting. This might be in
-                          conflict with other options that affect the file mode, like
-                          fsGroup, and the result can be other mode bits set.
-                        format: int32
-                        type: integer
-                      sources:
-                        description: list of volume projections
-                        items:
-                          description: Projection that may be projected along with
-                            other supported volume types
-                          properties:
-                            configMap:
-                              description: |-
-                                Adapts a ConfigMap into a projected volume.
-
-                                The contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
-                                    will be projected into the volume as a file whose
-                                    name is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the ConfigMap, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
-                                  type: boolean
-                              type: object
-                            downwardAPI:
-                              description: Represents downward API info for projecting
-                                into a projected volume. Note that this is identical
-                                to a downwardAPI volume source without the default
-                                mode.
-                              properties:
-                                items:
-                                  description: Items is a list of DownwardAPIVolume
-                                    file
-                                  items:
-                                    description: DownwardAPIVolumeFile represents
-                                      information to create the file containing the
-                                      pod field
-                                    properties:
-                                      fieldRef:
-                                        description: ObjectFieldSelector selects an
-                                          APIVersioned field of an object.
-                                        properties:
-                                          apiVersion:
-                                            description: Version of the schema the
-                                              FieldPath is written in terms of, defaults
-                                              to "v1".
-                                            type: string
-                                          fieldPath:
-                                            description: Path of the field to select
-                                              in the specified API version.
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: 'Required: Path is  the relative
-                                          path name of the file to be created. Must
-                                          not be absolute or contain the ''..'' path.
-                                          Must be utf-8 encoded. The first item of
-                                          the relative path must not start with ''..'''
-                                        type: string
-                                      resourceFieldRef:
-                                        description: ResourceFieldSelector represents
-                                          container resources (cpu, memory) and their
-                                          output format
-                                        properties:
-                                          containerName:
-                                            description: 'Container name: required
-                                              for volumes, optional for env vars'
-                                            type: string
-                                          divisor: {}
-                                          resource:
-                                            description: 'Required: resource to select'
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            secret:
-                              description: |-
-                                Adapts a secret into a projected volume.
-
-                                The contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.
-                              properties:
-                                items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
-                                    the listed keys will be projected into the specified
-                                    paths, and unlisted keys will not be present.
-                                    If a key is specified which is not present in
-                                    the Secret, the volume setup will error unless
-                                    it is marked optional. Paths must be relative
-                                    and may not contain the '..' path or start with
-                                    '..'.
-                                  items:
-                                    description: Maps a string key to a path within
-                                      a volume.
-                                    properties:
-                                      key:
-                                        description: The key to project.
-                                        type: string
-                                      mode:
-                                        description: 'Optional: mode bits to use on
-                                          this file, must be a value between 0 and
-                                          0777. If not specified, the volume defaultMode
-                                          will be used. This might be in conflict
-                                          with other options that affect the file
-                                          mode, like fsGroup, and the result can be
-                                          other mode bits set.'
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              type: object
-                            serviceAccountToken:
-                              description: ServiceAccountTokenProjection represents
-                                a projected service account token volume. This projection
-                                can be used to insert a service account token into
-                                the pods runtime filesystem for use against APIs (Kubernetes
-                                API Server or otherwise).
-                              properties:
-                                audience:
-                                  description: Audience is the intended audience of
-                                    the token. A recipient of a token must identify
-                                    itself with an identifier specified in the audience
-                                    of the token, and otherwise should reject the
-                                    token. The audience defaults to the identifier
-                                    of the apiserver.
-                                  type: string
-                                expirationSeconds:
-                                  description: ExpirationSeconds is the requested
-                                    duration of validity of the service account token.
-                                    As the token approaches expiration, the kubelet
-                                    volume plugin will proactively rotate the service
-                                    account token. The kubelet will start trying to
-                                    rotate the token if the token is older than 80
-                                    percent of its time to live or if the token is
-                                    older than 24 hours.Defaults to 1 hour and must
-                                    be at least 10 minutes.
-                                  format: int64
-                                  type: integer
-                                path:
-                                  description: Path is the path relative to the mount
-                                    point of the file to project the token into.
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                          type: object
-                        type: array
-                    required:
-                    - sources
-                    type: object
-                  quobyte:
-                    description: Represents a Quobyte mount that lasts the lifetime
-                      of a pod. Quobyte volumes do not support ownership management
-                      or SELinux relabeling.
-                    properties:
-                      group:
-                        description: Group to map volume access to Default is no group
-                        type: string
-                      readOnly:
-                        description: ReadOnly here will force the Quobyte volume to
-                          be mounted with read-only permissions. Defaults to false.
-                        type: boolean
-                      registry:
-                        description: Registry represents a single or multiple Quobyte
-                          Registry services specified as a string as host:port pair
-                          (multiple entries are separated with commas) which acts
-                          as the central registry for volumes
-                        type: string
-                      tenant:
-                        description: Tenant owning the given Quobyte volume in the
-                          Backend Used with dynamically provisioned Quobyte volumes,
-                          value is set by the plugin
-                        type: string
-                      user:
-                        description: User to map volume access to Defaults to serivceaccount
-                          user
-                        type: string
-                      volume:
-                        description: Volume is a string that references an already
-                          created Quobyte volume by name.
-                        type: string
-                    required:
-                    - registry
-                    - volume
-                    type: object
-                  rbd:
-                    description: Represents a Rados Block Device mount that lasts
-                      the lifetime of a pod. RBD volumes support ownership management
-                      and SELinux relabeling.
-                    properties:
-                      fsType:
-                        description: 'Filesystem type of the volume that you want
-                          to mount. Tip: Ensure that the filesystem type is supported
-                          by the host operating system. Examples: "ext4", "xfs", "ntfs".
-                          Implicitly inferred to be "ext4" if unspecified. More info:
-                          https://kubernetes.io/docs/concepts/storage/volumes#rbd'
-                        type: string
-                      image:
-                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      keyring:
-                        description: 'Keyring is the path to key ring for RBDUser.
-                          Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      monitors:
-                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        items:
-                          type: string
-                        type: array
-                      pool:
-                        description: 'The rados pool name. Default is rbd. More info:
-                          https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                      readOnly:
-                        description: 'ReadOnly here will force the ReadOnly setting
-                          in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      user:
-                        description: 'The rados user name. Default is admin. More
-                          info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                        type: string
-                    required:
-                    - monitors
-                    - image
-                    type: object
-                  scaleIO:
-                    description: ScaleIOVolumeSource represents a persistent ScaleIO
-                      volume
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Default is "xfs".
-                        type: string
-                      gateway:
-                        description: The host address of the ScaleIO API Gateway.
-                        type: string
-                      protectionDomain:
-                        description: The name of the ScaleIO Protection Domain for
-                          the configured storage.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      sslEnabled:
-                        description: Flag to enable/disable SSL communication with
-                          Gateway, default false
-                        type: boolean
-                      storageMode:
-                        description: Indicates whether the storage for a volume should
-                          be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                        type: string
-                      storagePool:
-                        description: The ScaleIO Storage Pool associated with the
-                          protection domain.
-                        type: string
-                      system:
-                        description: The name of the storage system as configured
-                          in ScaleIO.
-                        type: string
-                      volumeName:
-                        description: The name of a volume already created in the ScaleIO
-                          system that is associated with this volume source.
-                        type: string
-                    required:
-                    - gateway
-                    - system
-                    - secretRef
-                    type: object
-                  secret:
-                    description: |-
-                      Adapts a Secret into a volume.
-
-                      The contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.
-                    properties:
-                      defaultMode:
-                        description: 'Optional: mode bits to use on created files
-                          by default. Must be a value between 0 and 0777. Defaults
-                          to 0644. Directories within the path are not affected by
-                          this setting. This might be in conflict with other options
-                          that affect the file mode, like fsGroup, and the result
-                          can be other mode bits set.'
-                        format: int32
-                        type: integer
-                      items:
-                        description: If unspecified, each key-value pair in the Data
-                          field of the referenced Secret will be projected into the
-                          volume as a file whose name is the key and content is the
-                          value. If specified, the listed keys will be projected into
-                          the specified paths, and unlisted keys will not be present.
-                          If a key is specified which is not present in the Secret,
-                          the volume setup will error unless it is marked optional.
-                          Paths must be relative and may not contain the '..' path
-                          or start with '..'.
-                        items:
-                          description: Maps a string key to a path within a volume.
-                          properties:
-                            key:
-                              description: The key to project.
-                              type: string
-                            mode:
-                              description: 'Optional: mode bits to use on this file,
-                                must be a value between 0 and 0777. If not specified,
-                                the volume defaultMode will be used. This might be
-                                in conflict with other options that affect the file
-                                mode, like fsGroup, and the result can be other mode
-                                bits set.'
-                              format: int32
-                              type: integer
-                            path:
-                              description: The relative path of the file to map the
-                                key to. May not be an absolute path. May not contain
-                                the path element '..'. May not start with the string
-                                '..'.
-                              type: string
-                          required:
-                          - key
-                          - path
-                          type: object
-                        type: array
-                      optional:
-                        description: Specify whether the Secret or its keys must be
-                          defined
-                        type: boolean
-                      secretName:
-                        description: 'Name of the secret in the pod''s namespace to
-                          use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        type: string
-                    type: object
-                  storageos:
-                    description: Represents a StorageOS persistent volume resource.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      readOnly:
-                        description: Defaults to false (read/write). ReadOnly here
-                          will force the ReadOnly setting in VolumeMounts.
-                        type: boolean
-                      secretRef:
-                        description: LocalObjectReference contains enough information
-                          to let you locate the referenced object inside the same
-                          namespace.
-                        properties:
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                        type: object
-                      volumeName:
-                        description: VolumeName is the human-readable name of the
-                          StorageOS volume.  Volume names are only unique within a
-                          namespace.
-                        type: string
-                      volumeNamespace:
-                        description: VolumeNamespace specifies the scope of the volume
-                          within StorageOS.  If no namespace is specified then the
-                          Pod's namespace will be used.  This allows the Kubernetes
-                          name scoping to be mirrored within StorageOS for tighter
-                          integration. Set VolumeName to any name to override the
-                          default behaviour. Set to "default" if you are not using
-                          namespaces within StorageOS. Namespaces that do not pre-exist
-                          within StorageOS will be created.
-                        type: string
-                    type: object
-                  vsphereVolume:
-                    description: Represents a vSphere volume resource.
-                    properties:
-                      fsType:
-                        description: Filesystem type to mount. Must be a filesystem
-                          type supported by the host operating system. Ex. "ext4",
-                          "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                        type: string
-                      storagePolicyID:
-                        description: Storage Policy Based Management (SPBM) profile
-                          ID associated with the StoragePolicyName.
-                        type: string
-                      storagePolicyName:
-                        description: Storage Policy Based Management (SPBM) profile
-                          name.
-                        type: string
-                      volumePath:
-                        description: Path that identifies vSphere volume vmdk
-                        type: string
-                    required:
-                    - volumePath
-                    type: object
-                required:
-                - name
-                type: object
-              type: array
-            walCompression:
-              description: Enable compression of the write-ahead log using Snappy.
-                This flag is only available in versions of Prometheus >= 2.11.0.
-              type: boolean
-          required:
-          - arbitraryFSAccessThroughSMs
           type: object
         status:
           description: 'PrometheusStatus is the most recent observed status of the
@@ -10388,6 +6089,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: prometheusrules.monitoring.coreos.com
+  labels:
+    app: prometheus-operator
 spec:
   group: monitoring.coreos.com
   names:
@@ -10400,12 +6103,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
           description: ObjectMeta is metadata that all persisted resources must have,
@@ -10455,26 +6158,179 @@ spec:
 
                 If this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).
 
-                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency
               type: string
             generation:
               description: A sequence number representing a specific generation of
                 the desired state. Populated by the system. Read-only.
               format: int64
               type: integer
+            initializers:
+              description: Initializers tracks the progress of initialization.
+              properties:
+                pending:
+                  description: Pending is a list of initializers that must execute
+                    in order before this object is visible. When the last pending
+                    initializer is removed, and no failing result is set, the initializers
+                    struct will be set to nil and the object is considered as initialized
+                    and visible to all clients.
+                  items:
+                    description: Initializer is information about an initializer that
+                      has not yet completed.
+                    properties:
+                      name:
+                        description: name of the process that is responsible for initializing
+                          this object.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+                result:
+                  description: Status is a return value for calls that don't return
+                    other objects.
+                  properties:
+                    apiVersion:
+                      description: 'APIVersion defines the versioned schema of this
+                        representation of an object. Servers should convert recognized
+                        schemas to the latest internal value, and may reject unrecognized
+                        values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                      type: string
+                    code:
+                      description: Suggested HTTP return code for this status, 0 if
+                        not set.
+                      format: int32
+                      type: integer
+                    details:
+                      description: StatusDetails is a set of additional properties
+                        that MAY be set by the server to provide additional information
+                        about a response. The Reason field of a Status object defines
+                        what attributes will be set. Clients must ignore fields that
+                        do not match the defined type of each attribute, and should
+                        assume that any attribute may be empty, invalid, or under
+                        defined.
+                      properties:
+                        causes:
+                          description: The Causes array includes more details associated
+                            with the StatusReason failure. Not all StatusReasons may
+                            provide detailed causes.
+                          items:
+                            description: StatusCause provides more information about
+                              an api.Status failure, including cases when multiple
+                              errors are encountered.
+                            properties:
+                              field:
+                                description: |-
+                                  The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.
+
+                                  Examples:
+                                    "name" - the field "name" on the current resource
+                                    "items[0].name" - the field "name" on the first array entry in "items"
+                                type: string
+                              message:
+                                description: A human-readable description of the cause
+                                  of the error.  This field may be presented as-is
+                                  to a reader.
+                                type: string
+                              reason:
+                                description: A machine-readable description of the
+                                  cause of the error. If this value is empty there
+                                  is no information available.
+                                type: string
+                            type: object
+                          type: array
+                        group:
+                          description: The group attribute of the resource associated
+                            with the status StatusReason.
+                          type: string
+                        kind:
+                          description: 'The kind attribute of the resource associated
+                            with the status StatusReason. On some operations may differ
+                            from the requested resource Kind. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: The name attribute of the resource associated
+                            with the status StatusReason (when there is a single name
+                            which can be described).
+                          type: string
+                        retryAfterSeconds:
+                          description: If specified, the time in seconds before the
+                            operation should be retried. Some errors may indicate
+                            the client must take an alternate action - for those errors
+                            this field may indicate how long to wait before taking
+                            the alternate action.
+                          format: int32
+                          type: integer
+                        uid:
+                          description: 'UID of the resource. (when there is a single
+                            resource which can be described). More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
+                      type: object
+                    kind:
+                      description: 'Kind is a string value representing the REST resource
+                        this object represents. Servers may infer this from the endpoint
+                        the client submits requests to. Cannot be updated. In CamelCase.
+                        More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                      type: string
+                    message:
+                      description: A human-readable description of the status of this
+                        operation.
+                      type: string
+                    metadata:
+                      description: ListMeta describes metadata that synthetic resources
+                        must have, including lists and various status objects. A resource
+                        may have only one of {ObjectMeta, ListMeta}.
+                      properties:
+                        continue:
+                          description: continue may be set if the user set a limit
+                            on the number of items returned, and indicates that the
+                            server has more data available. The value is opaque and
+                            may be used to issue another request to the endpoint that
+                            served this list to retrieve the next set of available
+                            objects. Continuing a consistent list may not be possible
+                            if the server configuration has changed or more than a
+                            few minutes have passed. The resourceVersion field returned
+                            when using this continue value will be identical to the
+                            value in the first response, unless you have received
+                            this token from an error message.
+                          type: string
+                        resourceVersion:
+                          description: 'String that identifies the server''s internal
+                            version of this object that can be used by clients to
+                            determine when objects have changed. Value must be treated
+                            as opaque by clients and passed unmodified back to the
+                            server. Populated by the system. Read-only. More info:
+                            https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: selfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                      type: object
+                    reason:
+                      description: A machine-readable description of why this operation
+                        is in the "Failure" status. If this value is empty there is
+                        no information available. A Reason clarifies an HTTP status
+                        code but does not override it.
+                      type: string
+                    status:
+                      description: 'Status of the operation. One of: "Success" or
+                        "Failure". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status'
+                      type: string
+                  type: object
+              required:
+              - pending
+              type: object
             labels:
               description: 'Map of string keys and values that can be used to organize
                 and categorize (scope and select) objects. May match selectors of
                 replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
               type: object
             managedFields:
-              description: ManagedFields maps workflow-id and version to the set of
-                fields that are managed by that workflow. This is mostly for internal
-                housekeeping, and users typically shouldn't need to set or understand
-                this field. A workflow can be the user's name, a controller's name,
-                or the name of a specific apply path like "ci-cd". The set of fields
-                is always in the version that the workflow used when modifying the
-                object.
+              description: |-
+                ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+
+                This field is alpha and can be changed or removed without notice.
               items:
                 description: ManagedFieldsEntry is a workflow-id, a FieldSet and the
                   group version of the resource that the fieldset applies to.
@@ -10486,18 +6342,9 @@ spec:
                       the version of a field set because it cannot be automatically
                       converted.
                     type: string
-                  fieldsType:
-                    description: 'FieldsType is the discriminator for the different
-                      fields format and version. There is currently only one possible
-                      value: "FieldsV1"'
-                    type: string
-                  fieldsV1:
-                    description: |-
-                      FieldsV1 stores a set of fields in a data structure like a Trie, in JSON format.
-
-                      Each key is either a '.' representing the field itself, and will always map to an empty set, or a string representing a sub-field or item. The string will follow one of these four formats: 'f:<name>', where <name> is the name of a field in a struct, or key in a map 'v:<value>', where <value> is the exact json formatted value of a list item 'i:<index>', where <index> is position of a item in a list 'k:<keys>', where <keys> is a map of  a list item's key fields to their unique values If a key maps to an empty Fields value, the field that key represents is part of the set.
-
-                      The exact format is defined in sigs.k8s.io/structured-merge-diff
+                  fields:
+                    description: 'Fields stores a set of fields in a data structure
+                      like a Trie. To understand how this is used, see: https://github.com/kubernetes-sigs/structured-merge-diff'
                     type: object
                   manager:
                     description: Manager is an identifier of the workflow managing
@@ -10555,7 +6402,7 @@ spec:
                     description: If true, this reference points to the managing controller.
                     type: boolean
                   kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
                     type: string
                   name:
                     description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
@@ -10574,13 +6421,11 @@ spec:
               description: |-
                 An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
 
-                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency
               type: string
             selfLink:
-              description: |-
-                SelfLink is a URL representing this object. Populated by the system. Read-only.
-
-                DEPRECATED Kubernetes will stop propagating this field in 1.20 release and the field is planned to be removed in 1.21 release.
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
               type: string
             uid:
               description: |-
@@ -10639,6 +6484,10 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: servicemonitors.monitoring.coreos.com
+  labels:
+    app: prometheus-operator
+  annotations:
+    "helm.sh/hook": crd-install
 spec:
   group: monitoring.coreos.com
   names:
@@ -10651,12 +6500,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         spec:
           description: ServiceMonitorSpec contains specification parameters for a
@@ -10683,7 +6532,7 @@ spec:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description: Specify whether the Secret or it's key must
                               be defined
                             type: boolean
                         required:
@@ -10700,7 +6549,7 @@ spec:
                             description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           optional:
-                            description: Specify whether the Secret or its key must
+                            description: Specify whether the Secret or it's key must
                               be defined
                             type: boolean
                         required:
@@ -10710,23 +6559,6 @@ spec:
                   bearerTokenFile:
                     description: File to read bearer token for scraping targets.
                     type: string
-                  bearerTokenSecret:
-                    description: SecretKeySelector selects a key of a Secret.
-                    properties:
-                      key:
-                        description: The key of the secret to select from.  Must be
-                          a valid secret key.
-                        type: string
-                      name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      optional:
-                        description: Specify whether the Secret or its key must be
-                          defined
-                        type: boolean
-                    required:
-                    - key
-                    type: object
                   honorLabels:
                     description: HonorLabels chooses the metric's labels on collisions
                       with target labels.
@@ -10794,7 +6626,7 @@ spec:
                       to proxy through this endpoint.
                     type: string
                   relabelings:
-                    description: 'RelabelConfigs to apply to samples before scraping.
+                    description: 'RelabelConfigs to apply to samples before ingestion.
                       More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
                     items:
                       description: 'RelabelConfig allows dynamic rewriting of the
@@ -10852,40 +6684,18 @@ spec:
                   tlsConfig:
                     description: TLSConfig specifies TLS configuration parameters.
                     properties:
-                      ca: {}
                       caFile:
-                        description: Path to the CA cert in the Prometheus container
-                          to use for the targets.
+                        description: The CA cert to use for the targets.
                         type: string
-                      cert: {}
                       certFile:
-                        description: Path to the client cert file in the Prometheus
-                          container for the targets.
+                        description: The client cert file for the targets.
                         type: string
                       insecureSkipVerify:
                         description: Disable target certificate validation.
                         type: boolean
                       keyFile:
-                        description: Path to the client key file in the Prometheus
-                          container for the targets.
+                        description: The client key file for the targets.
                         type: string
-                      keySecret:
-                        description: SecretKeySelector selects a key of a Secret.
-                        properties:
-                          key:
-                            description: The key of the secret to select from.  Must
-                              be a valid secret key.
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          optional:
-                            description: Specify whether the Secret or its key must
-                              be defined
-                            type: boolean
-                        required:
-                        - key
-                        type: object
                       serverName:
                         description: Used to verify the hostname for the targets.
                         type: string
@@ -10976,3 +6786,4 @@ spec:
           type: object
       type: object
   version: v1
+---

--- a/prometheus-operator/install.sh
+++ b/prometheus-operator/install.sh
@@ -8,6 +8,21 @@ kubectl create namespace ${NAMESPACE}
 # Update your local Helm chart repository cache
 helm repo update
 
+# Ensure CRDs exist
+checkCRDs () {
+  kubectl -n ${NAMESPACE} wait --for condition=established --timeout=60s crd/alertmanagers.monitoring.coreos.com
+  kubectl -n ${NAMESPACE} wait --for condition=established --timeout=60s crd/podmonitors.monitoring.coreos.com
+  kubectl -n ${NAMESPACE} wait --for condition=established --timeout=60s crd/prometheuses.monitoring.coreos.com
+  kubectl -n ${NAMESPACE} wait --for condition=established --timeout=60s crd/prometheusrules.monitoring.coreos.com
+  kubectl -n ${NAMESPACE} wait --for condition=established --timeout=60s crd/servicemonitors.monitoring.coreos.com
+}
+
+BACKOFF=1
+until checkCRDs || [ $BACKOFF -eq 10 ]; do
+  printf 'Waiting for CRDs to exist...'
+  sleep $(( BACKOFF++ ))
+done
+
 # Install the prometheus-operator Helm chart
 helm install \
   --name prometheus-operator \

--- a/prometheus-operator/install.sh
+++ b/prometheus-operator/install.sh
@@ -6,11 +6,12 @@ HELM_CHART_VERSION=8.2.0
 kubectl create namespace ${NAMESPACE}
 
 # Update your local Helm chart repository cache
-helm3 repo update
+helm repo update
 
 # Install the prometheus-operator Helm chart
-helm3 install \
+helm install \
+  --name prometheus-operator \
   --namespace ${NAMESPACE} \
   --set prometheusOperator.createCustomResource=false \
   --version ${HELM_CHART_VERSION} \
-  prometheus-operator stable/prometheus-operator
+  stable/prometheus-operator

--- a/prometheus-operator/install.sh
+++ b/prometheus-operator/install.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
 NAMESPACE=monitoring
-HELM_CHART_VERSION=6.20.3
+HELM_CHART_VERSION=8.2.0
 # Create the namespace for prometheus-operator
 kubectl create namespace ${NAMESPACE}
 
 # Update your local Helm chart repository cache
-helm repo update
+helm3 repo update
 
 # Install the prometheus-operator Helm chart
-helm install \
-  --name prometheus-operator \
+helm3 install \
   --namespace ${NAMESPACE} \
   --set prometheusOperator.createCustomResource=false \
   --version ${HELM_CHART_VERSION} \
-  stable/prometheus-operator
+  prometheus-operator stable/prometheus-operator

--- a/prometheus-operator/manifest.yaml
+++ b/prometheus-operator/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: prometheus-operator
 title: "Prometheus Operator"
-version: 0.32.0
+version: 8.2.0
 maintainer: "@puck"
 description: Prometheus Operator App install prometheus, alertmanager, grafana and other tools to monitor your kubernetes cluster.
 url: https://github.com/coreos/prometheus-operator

--- a/prometheus-operator/manifest.yaml
+++ b/prometheus-operator/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: prometheus-operator
 title: "Prometheus Operator"
-version: 8.2.0
+version: 0.32.0
 maintainer: "@puck"
 description: Prometheus Operator App install prometheus, alertmanager, grafana and other tools to monitor your kubernetes cluster.
 url: https://github.com/coreos/prometheus-operator

--- a/prometheus-operator/manifest.yaml
+++ b/prometheus-operator/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: prometheus-operator
 title: "Prometheus Operator"
-version: 0.32.0
+version: 0.34.0
 maintainer: "@puck"
 description: Prometheus Operator App install prometheus, alertmanager, grafana and other tools to monitor your kubernetes cluster.
 url: https://github.com/coreos/prometheus-operator


### PR DESCRIPTION
* Upgrade helm chart from `6.20.3` to `8.2.0` and update the app version in the Civo manifest
* Update CRD's to reflect the new helm chart version
* Add bash loop to check for CRD's to exist before installing the chart

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot)

running chart externally with helm3 (rather than install tiller for testing):

```bash
~ % helm3 list
NAME               	NAMESPACE 	REVISION	UPDATED                                	STATUS  	CHART                    	APP VERSION
prometheus-operator	monitoring	1       	2019-11-15 12:56:06.365987947 -0500 EST	deployed	prometheus-operator-8.2.0	0.34.0   
```

----

Updated chart with servicemonitors working will now show actual data in prom/grafana:

![Screenshot from 2019-11-19 21-15-33](https://user-images.githubusercontent.com/4111646/69431690-3f3abb80-0d06-11ea-907e-11e891e8fba9.png)