### PR TITLE
Fix Postgres app - missing env var

### DIFF
--- a/postgresql/app.yaml
+++ b/postgresql/app.yaml
@@ -8,6 +8,7 @@ data:
   POSTGRES_DB: postgresdb
   POSTGRES_USER: $USERNAME
   POSTGRES_PASSWORD: $PASSWORD
+  PGDATA: /var/lib/postgresql/data/pgdata
 ---
 apiVersion: v1
 kind: PersistentVolume


### PR DESCRIPTION
The psotgres app was missing an env var that defined
where the data directory should be, looks like the
underlying volume had a lost+found dir
(linux root dir thing) that meant that postgres init
script failed to run

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>


If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot)

<img width="817" alt="Screenshot 2019-12-13 at 14 39 25" src="https://user-images.githubusercontent.com/40488132/70807877-5e34e680-1db6-11ea-9a3d-db4140779b3c.png">
