### PR TITLE
Upgrade the rancher app to 2.3.5

### DIFF
--- a/rancher/app.yaml
+++ b/rancher/app.yaml
@@ -46,7 +46,7 @@ spec:
       spec:
         serviceAccountName: cattle-admin
         containers:
-        - image: rancher/rancher:v2.3.0
+        - image: rancher/rancher:v2.3.5
           imagePullPolicy: Always
           name: cattle-server
           ports:


### PR DESCRIPTION
Currently, there is a bug in the Rancher 2.3.0 which causes errors when a user wants to view the `local/system` project. 

It has been fixed in the 2.3.2. Here you can find more details: https://github.com/rancher/rancher/issues/23613#
But I think it's always a good idea to update apps to the latest version.

Here is the screenshot with updated application. 
<img width="1487" alt="Screen Shot 2020-02-16 at 20 45 10" src="https://user-images.githubusercontent.com/20810956/74611558-3edf7000-50fd-11ea-81a0-4bfeb6b35f00.png">

It's probably something for @saiyam1814 (maintainer) or @andyjeffries (last contributor) to review. Thanks.