### PR TITLE
Upgrade Helm to 2.16.5. Closes #39.

### DIFF
--- a/helm/app.yaml
+++ b/helm/app.yaml
@@ -35,7 +35,7 @@ spec:
           value: kube-system
         - name: TILLER_HISTORY_MAX
           value: "0"
-        image: gcr.io/kubernetes-helm/tiller:v2.14.3
+        image: gcr.io/kubernetes-helm/tiller:v2.16.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/helm/manifest.yaml
+++ b/helm/manifest.yaml
@@ -1,6 +1,6 @@
 ---
 name: Helm
-version: 2.14.3
+version: 2.16.5
 maintainer: hello@civo.com
 description: Helm (tiller) helps you define, install, and upgrade even the most complex Kubernetes application.
 url: https://helm.sh


### PR DESCRIPTION
Helm 2.16.0 introduced Kubernetes 1.16 compatibility and I am unaware of any breaking change in 2.16 from 2.14. Whilst it would be a good idea to go to Helm 3, that is obviously a much more disruptive change.

Screenshot of Helm 2.16.5 running in my Civo k3s cluster:
![image](https://user-images.githubusercontent.com/11150054/77963586-86007980-72d5-11ea-8ac7-32d1fe7ea33d.png)