### PR TITLE
Update OpenFaaS to use helm3 via arkade

### DIFF
--- a/openfaas/install.sh
+++ b/openfaas/install.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml
+wget https://github.com/alexellis/arkade/releases/download/0.4.0/arkade
+chmod +x ./arkade
 
-helm repo add openfaas https://openfaas.github.io/faas-netes/
-
-kubectl -n openfaas create secret generic basic-auth \
---from-literal=basic-auth-user=admin \
---from-literal=basic-auth-password="$GATEWAY_PASSWORD"
-
-helm repo update \
- && helm upgrade openfaas --install openfaas/openfaas \
-    --namespace openfaas  \
-    --set basic_auth=true \
-    --set functionNamespace=openfaas-fn
-    #  --set serviceType=LoadBalancer
+./arkade install openfaas \
+  --basic-auth-password "$GATEWAY_PASSWORD"


### PR DESCRIPTION
Update OpenFaaS to use helm3 via arkade

arkade always has the most recent and up to date way to install 
openfaas. It is the official CLI installer, and can pull in helm3 into 
its own private folder $HOME/.arkade/bin/helm for the 
installation.

This PR should reduce maintenance overheads - whenever the 
install changes, we simply change arkade, and users benefit from 
the changes. The password name is the same, the value passed in 
from the Civo code works the same too.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alex@openfaas.com>

Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied