### PR TITLE
Add admin-user back

### DIFF
--- a/kubernetes-dashboard/app.yaml
+++ b/kubernetes-dashboard/app.yaml
@@ -300,3 +300,27 @@ spec:
       volumes:
         - name: tmp-volume
           emptyDir: {}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: admin-user
+  namespace: kubernetes-dashboard
+  


### PR DESCRIPTION
An update to the dashboard app (or possibly another reason) removed the admin-user ServiceAccount and ClusterRoleBinding that allowed a user to log in to the dashboard using a secret token. This update adds back the SA and CRB to allow the commands in post-install.md to work.

Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot)
<img width="844" alt="image" src="https://user-images.githubusercontent.com/44998809/87665214-7a3ea300-c75e-11ea-9374-9b75e8656c2c.png">
