### PR TITLE
Update apiVersion of Rancher

### DIFF
--- a/rancher/post_install.md
+++ b/rancher/post_install.md
@@ -6,7 +6,7 @@ By default external access to the Rancher isn't available. This is easily change
 
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: cattle-ingress


### PR DESCRIPTION
@saiyam1814, k3s 1.19.x is still in release candidate phase, however, I tested this update with success.
![image](https://user-images.githubusercontent.com/11750061/93267608-8a302e80-f771-11ea-895e-1c631f9567dd.png)

This group version of Ingress is deprecated by networking.k8s.io/v1beta1 Ingress. See the release notes for more information. https://kubernetes.io/docs/setup/release/notes/#ingress-graduates-to-general-availability

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied