### PR TITLE
fix Keptn installation

### DIFF
--- a/keptn/install.sh
+++ b/keptn/install.sh
@@ -2,7 +2,9 @@
 
 curl -sL https://get.keptn.sh | sudo -E bash
 
-keptn install --endpoint-service-type=ClusterIP --use-case=continuous-delivery
+echo "{}" > creds.json
+
+keptn install --endpoint-service-type=ClusterIP --use-case=continuous-delivery -c ./creds.json
 
 kubectl get deployments -n keptn
 


### PR DESCRIPTION
This fixes the prompt that was blocking the installation.

Providing an empty `creds.json` file will skip this prompt during the installation procedure