### PR TITLE
Fixed missing service account.

### DIFF
--- a/traefik2/app.yaml
+++ b/traefik2/app.yaml
@@ -49,6 +49,12 @@ rules:
       - list
       - watch
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: traefik-ingress-controller
+  namespace: traefik-controller
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -171,6 +177,7 @@ spec:
         app: traefik
         role: ingress-controller
     spec:
+      serviceAccountName: traefik-ingress-controller
       containers:
         - name: traefik
           image: 'traefik:v2.3'


### PR DESCRIPTION
A missing service account have been included in the traefik v2 app.yaml. Not sure how it was missed but nevertheless here it is!  
Also specified the service account on the traefik DaemonSet spec so that it have the correct account when searching for the resources.
