### PR TITLE
Minor fix to the traefik v2 manifest

### DIFF
--- a/traefik2/manifest.yaml
+++ b/traefik2/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: Traefik-v2
 title: Traefik v2
-version: 2.3
+version: "2.3"
 default: false
 maintainer: "johannes@jitesoft.com"
 description: An open source Edge Router working as an ingress controller and load balancer inside your kubernetes cluster.


### PR DESCRIPTION
The value `2.3` is parsed as a number in yaml, rather than version string, changed it to an explicit string type.