### PR TITLE
Fixed Wordpress init container

### DIFF
--- a/wordpress/app.yaml
+++ b/wordpress/app.yaml
@@ -55,15 +55,12 @@ spec:
         command: ["sh", "-c"]
         args:
         - if [ ! -e /var/www/html/civo-init.sh ]; then
-            if [ -e /var/www/html/wp-config.php ]; then
-              WP_CONFIG_FILE=/var/www/html/wp-config.php;
-            else
-              WP_CONFIG_FILE=/var/www/html/wp-config-sample.php;
-            fi;
+            WP_CONFIG_FILE=/var/www/html/wp-config-sample.php;
+
             echo "echo 'if (isset(\$_SERVER[\"HTTP_X_FORWARDED_PROTO\"]) && \$_SERVER[\"HTTP_X_FORWARDED_PROTO\"] === \"https\") {' >> $WP_CONFIG_FILE" >> /var/www/html/civo-init.sh;
-            echo "echo '    $_SERVER["HTTPS"] = "on";' >> $WP_CONFIG_FILE" >> /var/www/html/civo-init.sh;
+            echo "echo '    \$_SERVER[\"HTTPS\"] = "on";' >> $WP_CONFIG_FILE" >> /var/www/html/civo-init.sh;
             echo "echo '}' >> $WP_CONFIG_FILE" >> /var/www/html/civo-init.sh;
-            cat /var/www/html/civo-init.sh;
+            
             chmod +x /var/www/html/civo-init.sh;
           fi;
         volumeMounts:


### PR DESCRIPTION
The civo-init.sh was wrongly created without escape some characters.