### PR TITLE
WP post-install - bash instead of sh

### DIFF
--- a/wordpress/post_install.md
+++ b/wordpress/post_install.md
@@ -24,7 +24,7 @@ To simplify this configuration when the WordPress is installed an script is crea
 Use the following command to execute it when your WordPress pod reach running state.
 
 ```
- kubectl exec -it svc/wordpress -- sh -c /var/www/html/civo-init.sh
+ kubectl exec -it svc/wordpress -- bash -c /var/www/html/civo-init.sh
 ```
 
 After the script execution the following lines will be added to the *wp-config-sample.php* file, and they will be present in wp-config.php after wizard setup.


### PR DESCRIPTION
When following the original post-install instructions an error was displayed about `let` not found.
The script requires more than regular `sh` commands, running it with `bash` succeeds.