### PR TITLE
Add instruction to get MariaDB password for WordPress

### DIFF
--- a/wordpress/post_install.md
+++ b/wordpress/post_install.md
@@ -11,11 +11,14 @@ $ kubectl get secret mysql-pass --template={{.data.MYSQL_ROOT_PASSWORD}} | base6
 # copy the return value without the last % character
 ```
 
+Next, proceed with DB & user creation:
+
 ```
 $ kubectl exec -it svc/mariadb -- /bin/sh
 
 # mysql -u root -p
 Enter password: YOUR_ROOT_PASSWORD_HERE
+Note: if you're getting "Access denied for user 'root'@'localhost' (using password: YES)" error, exit from this exec session and try again in few seconds later
 
 MariaDB [(none)]> CREATE DATABASE wordpress_db;
 MariaDB [(none)]> CREATE USER wordpress_user identified by 'strong-password';

--- a/wordpress/post_install.md
+++ b/wordpress/post_install.md
@@ -4,6 +4,13 @@
 
 You'll need to create a user and a database in MariaDB before you can configure your Wordpress.
 
+First, you need the password for MariaDB.
+
+```
+$ kubectl get secret mysql-pass --template={{.data.MYSQL_ROOT_PASSWORD}} | base64 --decode
+# copy the return value without the last % character
+```
+
 ```
 $ kubectl exec -it svc/mariadb -- /bin/sh
 


### PR DESCRIPTION
It's not clear to me where to find the password for MariaDB to complete the WordPress post-installation steps. So, I decided to dig MariaDB manifest file and I saw [this line](https://github.com/civo/kubernetes-marketplace/blob/master/mariadb/app.yaml#L68).

I tried to decode the secret and I'm able to get the MariaDB prompt using that secret. Thus, here is my proposal to improve the WordPress post-installation step.

Current post-installation top section:

![Screen Shot 2020-12-16 at 3 03 04 PM](https://user-images.githubusercontent.com/75463191/102315864-d75daf80-3faf-11eb-9e02-bf776609776a.png)
