### PR TITLE
Fix None String Versions, breaking CIVO API

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ category: management
 
 The `name` is displayed in the web interface alongside the `logo.png`, and is searchable when you're installing marketplace applications from the CLI. If your application name has spaces in it, the `name` should be the spaces/hyphens version and you can add `title` which is a nicer display version.
 
-The `version` is a string of the version of the software being installed NOT the version of the marketplace configuration. If you want to include that, use an additional `-r1` or something after the version number. The `dependencies` are the names (can be lower case and part of the name) of any other marketplace applications that are needed by this application.
+The `version` is a **string** of the version of the software being installed NOT the version of the marketplace configuration. If you want to include that, use an additional `-r1` or something after the version number. The `dependencies` are the names (can be lower case and part of the name) of any other marketplace applications that are needed by this application. *This SHOULD be quoted to avoid breaking the CIVO API*
 
 The `maintainer` field can either be an email address (e.g. `hello@civo.com`) or a Twitter username (e.g. `@civocloud`) and isn't displayed on the site, but is used for us to determine who to contact if there are any problems with it. This is whoever submits the application to the marketplace (not the upstream provider), and is an implied agreement to offer help to the community with issues with it (or try to find a replacement maintainer if you are unable to do so any more).
 

--- a/falco/manifest.yaml
+++ b/falco/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: falco-security
 title: "Falco Security"
-version: 0.27
+version: "0.27"
 maintainer: amit2cha@gmail.com, Falco Maintainers
 description: Falco is a Cloud Native Runtime Security tool designed to detect anomalous activity in your applications.
 url: https://falco.org/

--- a/haproxy/manifest.yaml
+++ b/haproxy/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 title: "Haproxy"
-version: 1.5
+version: "1.5"
 maintainer: alejandro@civo.com, amit2cha@gmail.com
 description: HAProxy is free, open source software that provides a high availability load balancer and proxy server for TCP and HTTP-based applications.
 url: https://github.com/haproxytech/kubernetes-ingress


### PR DESCRIPTION
Fixes: ```Error: json: cannot unmarshal number into Go struct field KubernetesMarketplaceApplication.version of type string```
Values of x.y are cast to int by the API which breaks the go client

Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!

If your pull request is to submit a new application to the marketplace, please answer the following questions:

* [x] Have you followed the guidelines in our Contributing document in setting up the application?
* [x] Have you checked that the application your submission is proposing to add does not yet exist on the Marketplace, or as a pull request to be processed?
* [x] Have you tested your application on the Civo managed Kubernetes service? Please include a screenshot.
* [x] Can you confirm that the software you are submitting licensed for use in a publicly-available Kubernetes marketplace?

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot)
