### PR TITLE
Disable CertManager web hooks

### DIFF
--- a/cert-manager/install.sh
+++ b/cert-manager/install.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml
+kubectl delete -A ValidatingWebhookConfiguration cert-manager-webhook
+kubectl delete -A mutatingwebhookconfigurations cert-manager-webhook


### PR DESCRIPTION
With the new method of running clusters in Civo, the control planes nodes no longer have access to general nodes. As such, the cert-manager web hooks are not accessible.

This change removes the web hooks after install 


References:

- https://github.com/jetstack/cert-manager/issues/3645
