### PR TITLE
fix: remove Helm dependency from cert-manager

### DIFF
--- a/cert-manager/manifest.yaml
+++ b/cert-manager/manifest.yaml
@@ -5,6 +5,4 @@ version: v1.3.1
 maintainer: alex@openfaas.com
 description: cert-manager is a native Kubernetes certificate management controller
 url: https://cert-manager.io/docs/release-notes/release-notes-1.0/
-dependencies:
-  - Helm
 category: architecture


### PR DESCRIPTION
Helm hasn't been used for cert-manager since 62a2aac338dd263ef96086587c2fc619bf45c5de and I really don’t want tiller in my cluster 😀