### PR TITLE
Istio fixes

### DIFF
--- a/istio/install.sh
+++ b/istio/install.sh
@@ -43,7 +43,7 @@ echo "Downloading Istio Version $ISTIO_VERSION"
 
 NOHUP_FILE="$(basedir)/nohup.out"
 rm -f "$NOHUP_FILE"
-curl -L https://istio.io/downloadIstio | nohup sh - > "$NOHUP_FILE" 2>&1 &
+curl -sSL https://istio.io/downloadIstio | nohup sh - > "$NOHUP_FILE" 2>&1 &
 wait 
 
 ###########################################

--- a/istio/install.sh
+++ b/istio/install.sh
@@ -74,7 +74,7 @@ else
   -f https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/istio/istiod-service.yaml
 fi;
 
-wget https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/istio/control-plane.yaml -O - | \
+curl -sSL https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/istio/control-plane.yaml | \
   $ISTIOCTL_CMD install -y -n $ISTIO_NS --revision "$ISTIO_REVISION" -f -
 
 ###########################################
@@ -89,5 +89,5 @@ else
   kubectl create namespace $ISTIO_INGRESS_NS;
 fi;
 
-wget https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/istio/ingress-gateways.yaml -O - | \
+curl -sSL https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/istio/ingress-gateways.yaml | \
   $ISTIOCTL_CMD install -y -n $ISTIO_INGRESS_NS --revision "$ISTIO_REVISION" -f -

--- a/istio/uninstall.sh
+++ b/istio/uninstall.sh
@@ -20,11 +20,13 @@ fi
 
 echo "Downloading Istio Version $ISTIO_VERSION"
 
-curl -L https://istio.io/downloadIstio | nohup sh - &
-wait
+NOHUP_FILE="$(basedir)/nohup.out"
+rm -f "$NOHUP_FILE"
+curl -L https://istio.io/downloadIstio | nohup sh - > "$NOHUP_FILE" 2>&1 &
+wait 
 
 #ISTIO_DIR="istio-$ISTIO_VERSION"
-ISTIO_PATH=$(grep -oP '(?<=export PATH="\$PATH:).*(?=")' nohup.out)
+ISTIO_PATH=$(grep -oP '(?<=export PATH="\$PATH:).*(?=")' "$NOHUP_FILE")
 ISTIOCTL_CMD="$ISTIO_PATH/istioctl"
 
 # Delete Istio CRD and other resources

--- a/istio/uninstall.sh
+++ b/istio/uninstall.sh
@@ -22,7 +22,7 @@ echo "Downloading Istio Version $ISTIO_VERSION"
 
 NOHUP_FILE="$(basedir)/nohup.out"
 rm -f "$NOHUP_FILE"
-curl -L https://istio.io/downloadIstio | nohup sh - > "$NOHUP_FILE" 2>&1 &
+curl -sSL https://istio.io/downloadIstio | nohup sh - > "$NOHUP_FILE" 2>&1 &
 wait 
 
 #ISTIO_DIR="istio-$ISTIO_VERSION"


### PR DESCRIPTION
Fixing the assumptions on script execution directory 

- script and its file will use relative dir of install.sh script 
- use curl over wget to avoid writing temp files 
- add `sSL` to curl to show errors in case of failures