### PR TITLE
fix FluxCD URLs

### DIFF
--- a/flux/install.sh
+++ b/flux/install.sh
@@ -6,7 +6,7 @@ set -o pipefail
 FLUX_HOME=$(echo $HOME/.flux/bin)
 mkdir -p $FLUX_HOME
 
-curl -s https://toolkit.fluxcd.io/install.sh | bash -s -- "$FLUX_HOME"
+curl -s https://fluxcd.io/install.sh | bash -s -- "$FLUX_HOME"
 
 export PATH=$PATH:$FLUX_HOME
 

--- a/flux/post_install.md
+++ b/flux/post_install.md
@@ -1,7 +1,7 @@
 ## Flux
 
 Flux is a Continuous Delivery solution for Kubernetes.
-Flux is constructed with the [GitOps Toolkit](https://toolkit.fluxcd.io/components/),
+Flux is constructed with the [GitOps Toolkit](https://fluxcd.io/components/),
 a set of composable APIs and specialized tools for keeping Kubernetes clusters in sync
 with sources of configuration (like Git & Helm repositories), and automating updates
 to configuration when there is new code to deploy.
@@ -14,12 +14,12 @@ Flux is a [CNCF](https://cncf.io) project made for:
 
 ### Usage instruction
 
-To get started with Flux, [browse the documentation](https://toolkit.fluxcd.io) or try the following guides:
+To get started with Flux, [browse the documentation](https://fluxcd.io) or try the following guides:
 
-- [Get started with Flux](https://toolkit.fluxcd.io/get-started/)
+- [Get started with Flux](https://fluxcd.io/get-started/)
 - [GitOps workflow for multi-env deployments with Flux, Kustomize and Helm](https://github.com/fluxcd/flux2-kustomize-helm-example)
-- [Manage Kubernetes secrets with Mozilla SOPS](https://toolkit.fluxcd.io/guides/mozilla-sops/)
-- [Automate container image updates to Git](https://toolkit.fluxcd.io/guides/image-update/)
+- [Manage Kubernetes secrets with Mozilla SOPS](https://fluxcd.io/guides/mozilla-sops/)
+- [Automate container image updates to Git](https://fluxcd.io/guides/image-update/)
 - [Manage multi-tenant clusters with Flux](https://github.com/fluxcd/flux2-multi-tenancy)
 
 ## Upgrade instruction
@@ -27,7 +27,7 @@ To get started with Flux, [browse the documentation](https://toolkit.fluxcd.io) 
 Install the latest Flux CLI:
 
 - Homebrew: `brew install fluxcd/tap/flux`
-- Bash: `curl -s https://toolkit.fluxcd.io/install.sh | sudo bash`
+- Bash: `curl -s https://fluxcd.io/install.sh | sudo bash`
 
 Binaries for macOS AMD64/AARCH64, Linux AMD64/ARM and Windows are available for download on the
 [release page](https://github.com/fluxcd/flux2/releases).

--- a/flux/post_install.md
+++ b/flux/post_install.md
@@ -1,7 +1,7 @@
 ## Flux
 
 Flux is a Continuous Delivery solution for Kubernetes.
-Flux is constructed with the [GitOps Toolkit](https://fluxcd.io/components/),
+Flux is constructed with the [GitOps Toolkit](https://fluxcd.io/docs/components/),
 a set of composable APIs and specialized tools for keeping Kubernetes clusters in sync
 with sources of configuration (like Git & Helm repositories), and automating updates
 to configuration when there is new code to deploy.
@@ -16,10 +16,10 @@ Flux is a [CNCF](https://cncf.io) project made for:
 
 To get started with Flux, [browse the documentation](https://fluxcd.io) or try the following guides:
 
-- [Get started with Flux](https://fluxcd.io/get-started/)
+- [Get started with Flux](https://fluxcd.io/docs/get-started/)
 - [GitOps workflow for multi-env deployments with Flux, Kustomize and Helm](https://github.com/fluxcd/flux2-kustomize-helm-example)
-- [Manage Kubernetes secrets with Mozilla SOPS](https://fluxcd.io/guides/mozilla-sops/)
-- [Automate container image updates to Git](https://fluxcd.io/guides/image-update/)
+- [Manage Kubernetes secrets with Mozilla SOPS](https://fluxcd.io/docs/guides/mozilla-sops/)
+- [Automate container image updates to Git](https://fluxcd.io/docs/guides/image-update/)
 - [Manage multi-tenant clusters with Flux](https://github.com/fluxcd/flux2-multi-tenancy)
 
 ## Upgrade instruction


### PR DESCRIPTION
If your pull request concerns an existing Marketplace application, please make sure you have:

* [X] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [X] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [X] Tested that the application works with the proposed updates applied (including a screenshot)

This is just a change which fixes the URL of `toolkit.fluxcd.io` to just `fluxcd.io`.

Test:
```sh
curl -Is https://fluxcd.io/install.sh
HTTP/2 200
accept-ranges: bytes
cache-control: public, max-age=0, must-revalidate
content-length: 5600
content-type: application/x-shellscript
date: Sun, 25 Jul 2021 18:13:47 GMT
strict-transport-security: max-age=31536000
age: 3260
etag: "910be6a0f291257fc5e2534e74d4b28b-ssl"
server: Netlify
x-nf-request-id: 01FBFH2FF51VCK26W15655FEGS
```

@stefanprodan this fixes #229 .

