### PR TITLE
create namespace in helm via flag

### DIFF
--- a/reloader/install.sh
+++ b/reloader/install.sh
@@ -3,6 +3,4 @@
 helm repo add stakater https://stakater.github.io/stakater-charts
 helm repo update
 
-kubectl create namespace reloader
-
-helm install reloader stakater/reloader --version v0.0.91 --namespace reloader
+helm install reloader stakater/reloader --version v0.0.91 --namespace reloader --create-namespace


### PR DESCRIPTION
My proposal is change kubectl create namespace command to add flag in helm command `--create-namespace` to code be more readable.

![Screen Shot 2021-08-12 at 4 05 19 PM](https://user-images.githubusercontent.com/20422385/129254385-02517b31-973d-46cb-bce5-2ee162319dbc.png)

