### PR TITLE
Add the gitlab namespace to get the root secret

### DIFF
--- a/gitlab/post_install.md
+++ b/gitlab/post_install.md
@@ -9,7 +9,7 @@ You can get started with the [GitLab Documentation](https://docs.gitlab.com/ee/)
 You can access the GitLab instance by visiting the domain specified during installation. The default domain would be `gitlab.$CLLUSTER_ID.k8s.civo.com`. The initial login user is `root` and password you can get from following command 
 
 ```
-kubectl get secret -n gitlab gitlab-gitlab-initial-root-password -ojsonpath='{.data.password}' | base64 --decode ; echo
+kubectl get secret -n gitlab gitlab-gitlab-initial-root-password --namespace gitlab -ojsonpath='{.data.password}' | base64 --decode ; echo
 
 ```
 


### PR DESCRIPTION
To avoid the following error `Error from server (NotFound): secrets "gitlab-gitlab-initial-root-password" not found` we need to specify `--namespace gitlab`

Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot)
