### PR TITLE
fix: traefik2 metrics and dashboard.

### DIFF
--- a/traefik2/app.yaml
+++ b/traefik2/app.yaml
@@ -180,7 +180,7 @@ spec:
       serviceAccountName: traefik-ingress-controller
       containers:
         - name: traefik
-          image: 'traefik:v2.3'
+          image: 'traefik:v2.5'
           args:
             - --api
             - --api.dashboard
@@ -194,7 +194,7 @@ spec:
             - --metrics.prometheus.buckets=0.100000, 0.300000, 1.200000, 5.000000
             - --metrics.prometheus.addEntryPointsLabels=true
             - --metrics.prometheus.addServicesLabels=true
-            - --entryPoints.metrics.address=:8080
+            - --entryPoints.metrics.address=:9000
             - --metrics.prometheus.entryPoint=metrics
           ports:
             - name: web
@@ -204,7 +204,7 @@ spec:
               containerPort: 443
               protocol: TCP
             - name: metrics
-              containerPort: 8080
+              containerPort: 9000
               protocol: TCP
           resources:
             requests:

--- a/traefik2/manifest.yaml
+++ b/traefik2/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: Traefik-v2
 title: Traefik v2
-version: "2.3"
+version: "2.5"
 default: false
 maintainer: "johannes@jitesoft.com"
 description: An open source Edge Router working as an ingress controller and load balancer inside your kubernetes cluster.

--- a/traefik2/post_install.md
+++ b/traefik2/post_install.md
@@ -60,8 +60,8 @@ websecure endpoint (443).
 
 ### Dashboard
 
-The traefik api / dashboard is enabled by default on the `internal@api`. If you do not wish to set up a ingress route to
-the dashboard, you can update the DaemonSet and add the following values:
+The traefik api / dashboard is enabled by default on `internal@api` (default TraefikService). 
+If you do not wish to set up an ingress route to the dashboard, you can update the DaemonSet and add the following values:
 
 ```yaml
 args:

--- a/traefik2/post_install.md
+++ b/traefik2/post_install.md
@@ -57,3 +57,20 @@ This will open up http://www.example.com (assuming you pointed that non-real dom
 Port 80 and 443 are both exposed through a `LoadBalancer` service, with the help of [cert-manager](https://cert-manager.io/) you can
 issue your own TLS/SSL certificates for your domains, by default, Traefik generates a self-signed certificate for the
 websecure endpoint (443). 
+
+### Dashboard
+
+The traefik api / dashboard is enabled by default on the `internal@api`. If you do not wish to set up a ingress route to
+the dashboard, you can update the DaemonSet and add the following values:
+
+```yaml
+args:
+  - '--api.insecure'
+...
+ports:
+  - name: api
+    containerPort: 8080
+    protocol: TCP
+```
+
+When that is done, it's possible to access the dashboard and api through a port-forward on 8080.


### PR DESCRIPTION
This PR include the following changes to the traefik2 marketplace app:

* Traefik was updated to version 2.5 (from 2.3).
* The default metrics port was changed from 8080 to 9000 (more standard for metrics) to enable easier access to api/dashboard.
* Documentation was updated with information on how to access the dashboard.