### PR TITLE
fix: Change Argo Workflows executor

### DIFF
--- a/argo-workflows/Makefile
+++ b/argo-workflows/Makefile
@@ -1,10 +1,14 @@
 build: app.yaml
 
 app.yaml:
-	@kubectl create --dry-run=client ns -o yaml argo >> app.yaml
+	@kubectl create --dry-run=client ns -o yaml argo > app.yaml
 	@echo --- >> app.yaml
-	@kubectl apply --dry-run=client -n argo -o yaml -f https://raw.githubusercontent.com/argoproj/argo-workflows/stable/manifests/install.yaml >> app.yaml
-	@sed -i '' -e '/^version:/d' manifest.yaml
+	@kubectl -n argo create configmap workflow-controller-configmap --dry-run=client -o yaml --from-file=config >> app.yaml
+	@echo --- >> app.yaml
+	@kubectl apply --dry-run=client -n argo -o json -f https://raw.githubusercontent.com/argoproj/argo-workflows/stable/manifests/install.yaml | \
+		jq 'del(.items[] | select(.metadata.name == "workflow-controller-configmap"))' | \
+		kubectl apply --dry-run=client -n argo -o yaml -f - >> app.yaml
+	@sed -i -e '/^version:/d' manifest.yaml
 	@grep -m1 'image: .*/workflow-controller:' app.yaml | cut -d: -f3 | sed 's/\(.*\)/version: "\1"/' >> manifest.yaml
 .PHONY: clean
 clean:

--- a/argo-workflows/app.yaml
+++ b/argo-workflows/app.yaml
@@ -7,6 +7,16 @@ spec: {}
 status: {}
 ---
 apiVersion: v1
+data:
+  config: |
+    containerRuntimeExecutor: pns
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: workflow-controller-configmap
+  namespace: argo
+---
+apiVersion: v1
 items:
 - apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
@@ -548,14 +558,6 @@ items:
   subjects:
   - kind: ServiceAccount
     name: argo-server
-    namespace: argo
-- apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    annotations:
-      kubectl.kubernetes.io/last-applied-configuration: |
-        {"apiVersion":"v1","kind":"ConfigMap","metadata":{"annotations":{},"name":"workflow-controller-configmap","namespace":"argo"}}
-    name: workflow-controller-configmap
     namespace: argo
 - apiVersion: v1
   kind: Service

--- a/argo-workflows/config
+++ b/argo-workflows/config
@@ -1,0 +1,1 @@
+containerRuntimeExecutor: pns


### PR DESCRIPTION
The container runtime executor for workflows defaults to docker.
Since Civo kubernetes is based on k3s, containerd is used instead
of docker. So jobs submitted to workflows fail unless the container
rutime executor is updated to pns(process namespace sharing)

Signed-off-by: Sibu Thomas Mathew <sibuthomasmathew@gmail.com>

Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot)

## Output before the change

```bash
$ kubectl get nodes
NAME                                                     STATUS   ROLES    AGE   VERSION
k3s-accure-workflow-cluster-776d-63c6ae-node-pool-1b25   Ready    <none>   10m   v1.20.2+k3s1
k3s-accure-workflow-cluster-776d-63c6ae-node-pool-7a04   Ready    <none>   12m   v1.20.2+k3s1
$ 
$ 
$ kubectl -n argo describe cm workflow-controller-configmap
Name:         workflow-controller-configmap
Namespace:    argo
Labels:       <none>
Annotations:  <none>

Data
====

BinaryData
====

Events:  <none>
$ 
$ 
$ kubectl get pods
NAME                READY   STATUS              RESTARTS   AGE
hello-world-zkqsh   0/2     ContainerCreating   0          6m41s
$ 
$ 
$ kubectl describe pod hello-world-zkqsh | tail
QoS Class:       BestEffort
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason       Age                  From               Message
  ----     ------       ----                 ----               -------
  Normal   Scheduled    7m8s                 default-scheduler  Successfully assigned default/hello-world-zkqsh to k3s-accure-workflow-cluster-776d-63c6ae-node-pool-1b25
  Warning  FailedMount  56s (x11 over 7m8s)  kubelet            MountVolume.SetUp failed for volume "docker-sock" : hostPath type check failed: /var/run/docker.sock is not a socket file
  Warning  FailedMount  29s (x3 over 5m5s)   kubelet            Unable to attach or mount volumes: unmounted volumes=[docker-sock], unattached volumes=[podmetadata docker-sock default-token-gwjzd]: timed out waiting for the condition
$ 
```

## After the change

```bash
$ kubectl get nodes
NAME                                                     STATUS   ROLES    AGE   VERSION
k3s-accure-workflow-cluster-776d-63c6ae-node-pool-1b25   Ready    <none>   16m   v1.20.2+k3s1
k3s-accure-workflow-cluster-776d-63c6ae-node-pool-7a04   Ready    <none>   17m   v1.20.2+k3s1
$ 
$ 
$ kubectl -n argo describe cm workflow-controller-configmap
Name:         workflow-controller-configmap
Namespace:    argo
Labels:       <none>
Annotations:  <none>

Data
====
config:
----
containerRuntimeExecutor: pns


BinaryData
====

Events:  <none>
$
$  
$ kubectl  get pods -w
NAME                READY   STATUS              RESTARTS   AGE
hello-world-lq9vs   0/2     ContainerCreating   0          11s
hello-world-lq9vs   1/2     NotReady            0          25s
hello-world-lq9vs   0/2     Completed           0          51s
^C$ 
$ 
$ 
$ kubectl describe pod hello-world-lq9vs | tail
  ----    ------     ----  ----               -------
  Normal  Scheduled  72s   default-scheduler  Successfully assigned default/hello-world-lq9vs to k3s-accure-workflow-cluster-776d-63c6ae-node-pool-1b25
  Normal  Pulling    72s   kubelet            Pulling image "argoproj/argoexec:v3.0.3"
  Normal  Pulled     61s   kubelet            Successfully pulled image "argoproj/argoexec:v3.0.3" in 11.544769944s
  Normal  Created    60s   kubelet            Created container wait
  Normal  Started    60s   kubelet            Started container wait
  Normal  Pulling    60s   kubelet            Pulling image "docker/whalesay:latest"
  Normal  Pulled     49s   kubelet            Successfully pulled image "docker/whalesay:latest" in 10.942951694s
  Normal  Created    49s   kubelet            Created container main
  Normal  Started    49s   kubelet            Started container main
$ 
```