### PR TITLE
Fix wordpress pod goes into a CrashLoopBackOff loop after install

### DIFF
--- a/wordpress/post_install.md
+++ b/wordpress/post_install.md
@@ -55,3 +55,14 @@ If you want to change the hostname or modify the ingress, edit it with
 ```
 kubectl edit ingress wordpress
 ```
+
+## Troubleshooting
+
+In some cases, after install has finished `wordpress` pod goes into a CrashLoopBackOff loop, because readiness probe fails.
+
+One possible solution should be to add the following lines into *wp-config.php*.
+
+```
+define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST'] . '/');
+define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] . '/');
+```


### PR DESCRIPTION
I have installed latest version of Wordpress to my fresh new cluster, and after install it went into a CrashLoopBackOff, because readiness probe had some issue. After i extended my `wp-config.php` it gone.