### PR TITLE
[docs]: change `--app` to `--applications` in testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 Once an application is part of the marketplace, you can install it using the GUI on Civo.com or by using the [Civo CLI](https://github.com/civo/cli) with a command line:
 
 ```
-civo k8s create my-cluster --app=longhorn,minio
+civo k8s create my-cluster --applications=longhorn,minio
 
 # or
 
@@ -132,7 +132,7 @@ Testing a marketplace application during development is easy, use the Civo CLI t
 
 ```
 # Create a cluster with any prerequisites
-civo k8s create my-cluster --app=longhorn --save --wait
+civo k8s create my-cluster --applications=longhorn --save --wait
 
 # Then apply your app.yaml
 kubectl apply -f app.yaml


### PR DESCRIPTION
Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!

If your pull request is to submit a new application to the marketplace, please answer the following questions:

* [x] Have you followed the guidelines in our Contributing document in setting up the application?
* [x] Have you checked that the application your submission is proposing to add does not yet exist on the Marketplace, or as a pull request to be processed?
* [x] Have you tested your application on the Civo managed Kubernetes service? Please include a screenshot.
* [x] Can you confirm that the software you are submitting licensed for use in a publicly-available Kubernetes marketplace?

If your pull request concerns an existing Marketplace application, please make sure you have:

* [ ] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [ ] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [ ] Tested that the application works with the proposed updates applied (including a screenshot)

---

Change to the testing docs. The tells us to use `--app` in the docs, but the flag is `--applications` in the latest version (1.0.26) of the CLI app