### PR TITLE
Bump KubeVela: Install Velaux by default

### DIFF
--- a/kubevela/install.sh
+++ b/kubevela/install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-helm repo add kubevela https://charts.kubevela.net/core
-helm repo update
-helm install --create-namespace -n vela-system kubevela kubevela/vela-core --wait --version v1.5.2
+curl -fsSl https://static.kubevela.net/script/install.sh | sudo bash -s 1.5.3
+vela install
+
+## enable velaux by default
+
+vela addon enable velaux

--- a/kubevela/manifest.yaml
+++ b/kubevela/manifest.yaml
@@ -1,6 +1,6 @@
 ---
 name: KubeVela
-version: 0.1.0
+version: 0.2.0
 maintainer: qiaozhongpei.qzp@alibaba-inc.com
 description: The Modern Application Platform.
 url: https://kubevela.io

--- a/kubevela/post_install.md
+++ b/kubevela/post_install.md
@@ -1,42 +1,32 @@
 ## KubeVela
 
-KubeVela is a modern software delivery control plane. The goal is to make deploying and operating applications across 
-today's hybrid, multi-cloud environments easier, faster and more reliable. KubeVela is a [CNCF](https://cncf.io) project. 
+KubeVela is a modern software delivery control plane. The goal is to make deploying and operating applications across
+today's hybrid, multi-cloud environments easier, faster and more reliable. KubeVela is a [CNCF](https://cncf.io) project.
 Welcome onboard and sail Vela!
+
+### Quick Start
+
+VelaUX is enabled by default as a dashboard to helps you get started with KubeVela quickly. It provides end-to-end
+application delivery and management experience.
+
+You can access the VelaUX dashboard using the following command:
+
+The default username is `admin` and the password is `VelaUX12345`.
+
+```shell
+kubectl port-forward svc/velaux -n vela-system 9082:80
+```
+
+Please must set and remember the new password after the first login.
 
 ### Install Vela CLI
 
+Vela CLI is a command line tool for KubeVela. It provides a set of commands to help you manage your applications.
 Download and install the latest `vela` CLI in your local machine:
 
 ```shell
 curl -fsSl https://kubevela.net/script/install.sh | bash
 ```
-
-### Install VelaUX
-
-VelaUX provides end-to-end application delivery and management experience, including API services and UI dashboard. It's
-an addon to KubeVela, and can be installed by the following command:
-
-```shell
-vela addon enable velaux
-```
-
-Expected output:
-
-```shell
-Addon: velaux enabled Successfully.
-```
-
-Access the VelaUX dashboard by
-
-```shell
-vela port-forward addon-velaux -n vela-system 9082:80
-```
-
-Choose > local | velaux | velaux for visit. The default username is admin and the password is VelaUX12345. 
-Please must set and remember the new password after the first login.
-
-For more instruction about enable VelaUX with different options, please refer to [VelaUX](https://kubevela.net/docs/reference/addons/velaux).
 
 ### Using KubeVela
 
@@ -47,5 +37,5 @@ KubeVela using a unified model to describe the application. To get started:
 
 ### Support
 
-If you need help, welcome to the [community](https://github.com/kubevela/community#communication) to ask questions. Or 
+If you need help, welcome to the [community](https://github.com/kubevela/community#communication) to ask questions. Or
 open an issue in [GitHub](https://github.com/kubevela/kubevela/issues)


### PR DESCRIPTION
Signed-off-by: Qiaozp <qiaozhongpei.qzp@alibaba-inc.com>

Install VelaUX by default so that user can have a quick start.


If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot).
* [x] Updated the version number of the app if that has changed.
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/47812250/187621270-6d0b9d1d-697b-40d3-8f02-c71ed967ede4.png">
<img width="1502" alt="image" src="https://user-images.githubusercontent.com/47812250/187621804-8dfece32-7938-4cec-a817-fc94542a9dd6.png">
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/47812250/187621879-91c69009-6e79-4787-987a-a9b5a8d6e6e2.png">

