### PR TITLE
Update Epinio 1.4.0

### DIFF
--- a/epinio/install.sh
+++ b/epinio/install.sh
@@ -9,4 +9,4 @@ helm repo add epinio https://epinio.github.io/helm-charts
 helm repo update
 kubectl create namespace epinio
 
-helm upgrade --install epinio epinio/epinio --namespace epinio --set global.domain="$SYSTEM_DOMAIN" --wait
+helm upgrade --install epinio epinio/epinio --namespace epinio --set global.domain="$SYSTEM_DOMAIN" --version 1.4.0 --wait

--- a/epinio/manifest.yaml
+++ b/epinio/manifest.yaml
@@ -1,5 +1,5 @@
 name: Epinio
-version: v1.3.0
+version: v1.4.0
 maintainer: "@enrichman"
 description: "The Application Development Engine for Kubernetes"
 url: https://epinio.io/


### PR DESCRIPTION
Yesterday Epinio v1.4.0 was released: https://github.com/epinio/epinio/releases/tag/v1.4.0

Updating the Epinio app to the latest version, and also pinning the helm-chart version to the one matching the 
CIVO manifest.yaml file, to avoid unexpected releases.