### PR TITLE
Skip UpdateCLI Github Action on Forks

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' && !github.event.pull_request.head.repo.fork
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,7 +15,8 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && !github.event.pull_request.head.repo.fork
+    # Only run on non-forked repos
+    if: github.ref == 'refs/heads/master' && github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -16,7 +16,7 @@ jobs:
   updatecli:
     runs-on: ubuntu-latest
     # Only run on non-forked repos
-    if: github.ref == 'refs/heads/master' && github.event.pull_request.head.repo.fork == false
+    if: github.ref == 'refs/heads/master' && github.repository.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -15,8 +15,7 @@ permissions:
 jobs:
   updatecli:
     runs-on: ubuntu-latest
-    # Only run on non-forked repos
-    if: github.ref == 'refs/heads/master' && github.repository.fork == false
+    if: ${{ github.ref == 'refs/heads/master' && github.repository_owner == 'civo' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Skip "UpdateCLI" on forks.  Observed an error when updating [my fork](https://github.com/ssmiller25/kubernetes-marketplace/actions/runs/4461108999/jobs/7834706211#logs).  For now, easier to skip this step on Forks as I assume the targeting applications in this particular action will be maintained by Civo directly.  While normally someone who forks will disable actions, if they do not it will result in failed running attempts in their repo.