### PR TITLE
Argocd update pipeline should uses the chart version

### DIFF
--- a/.github/updatecli/updatecli.d/argocd.yaml
+++ b/.github/updatecli/updatecli.d/argocd.yaml
@@ -44,7 +44,7 @@ conditions:
     # is correctly published on the argoproj helm repository
     kind: helmchart
     name: Get latest Argocd Helm Chart version
-    sourceid: app
+    sourceid: chart
     spec:
       url: https://argoproj.github.io/argo-helm
       name: argo-cd


### PR DESCRIPTION
While looking at the Updatecli pipeline, I noticed that I made a mistake, the argocd pipeline will never work because it uses the app version instead of the chart version to verify that the latest argocd cd chart version is available on the Helm chart registry

```
CONDITIONS:
===========

chart
-----
✗ Helm Chart 'argo-cd' isn't available on https://argoproj.github.io/argo-helm for version 'v2.6.7'
	 => expected condition result false, got false
```

and it should be 

```
CONDITIONS:
===========

chart
-----
✔ Helm Chart 'argo-cd' is available on https://argoproj.github.io/argo-helm for version '5.28.0'

```