### PR TITLE
Update FerretDB to version 1.0

### DIFF
--- a/ferretdb/app.yaml
+++ b/ferretdb/app.yaml
@@ -26,16 +26,37 @@ spec:
         app: ferretdb
     spec:
       containers:
-        - image: ghcr.io/ferretdb/all-in-one:0.9.4-rc.2
+        - image: ghcr.io/ferretdb/ferretdb:1.0.0
           name: ferretdb
           env:
-            # remove default username and password
             - name: FERRETDB_POSTGRESQL_URL
               value: postgres://127.0.0.1:5432/ferretdb
+            - name: FERRETDB_STATE_DIR
+              value: /state
+            - name: FERRETDB_TEST_TELEMETRY_PACKAGE
+              value: civo
+          volumeMounts:
+            - name: ferretdb-persistent-storage
+              mountPath: /state
+              subPath: ferretdb
+          ports:
+            - containerPort: 27017
+              name: ferretdb
+        - image: postgres:15.2
+          name: postgresql
+          env:
             - name: POSTGRES_USER
               value: $POSTGRES_USER
             - name: POSTGRES_PASSWORD
               value: $POSTGRES_PASSWORD
+          volumeMounts:
+            - name: ferretdb-persistent-storage
+              mountPath: /var/lib/postgresql/data
+              subPath: postgresql
           ports:
-            - containerPort: 27017
-              name: ferretdb
+            - containerPort: 5432
+              name: postgresql
+      volumes:
+        - name: ferretdb-persistent-storage
+          persistentVolumeClaim:
+            claimName: ferretdb-pv-claim

--- a/ferretdb/app.yaml
+++ b/ferretdb/app.yaml
@@ -1,5 +1,16 @@
 ---
 apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ferretdb-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: $VOLUME_SIZE
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: ferretdb
@@ -49,6 +60,10 @@ spec:
               value: $POSTGRES_USER
             - name: POSTGRES_PASSWORD
               value: $POSTGRES_PASSWORD
+            - name: POSTGRES_DB
+              value: ferretdb
+            - name:  PGDATA
+              value: /var/lib/postgresql/data
           volumeMounts:
             - name: ferretdb-persistent-storage
               mountPath: /var/lib/postgresql/data

--- a/ferretdb/manifest.yaml
+++ b/ferretdb/manifest.yaml
@@ -8,7 +8,7 @@ category: database
 configuration:
   POSTGRES_USER:
     label: "PostgreSQL superuser name"
-    value: "CIVO:WORDS(10)"
+    value: "CIVO:WORDS(2)"
   POSTGRES_PASSWORD:
     label: "PostgreSQL superuser password"
     value: "CIVO:ALPHANUMERIC(30)"

--- a/ferretdb/manifest.yaml
+++ b/ferretdb/manifest.yaml
@@ -5,6 +5,19 @@ maintainer: packages@ferretdb.io
 description: A truly Open Source MongoDB alternative.
 url: https://www.ferretdb.io
 category: database
+plans:
+  - label: "5GB"
+    configuration:
+      VOLUME_SIZE:
+        value: 5Gi
+  - label: "10GB"
+    configuration:
+      VOLUME_SIZE:
+        value: 10Gi
+  - label: "20GB"
+    configuration:
+      VOLUME_SIZE:
+        value: 20Gi
 configuration:
   POSTGRES_USER:
     label: "PostgreSQL superuser name"

--- a/ferretdb/post_install.md
+++ b/ferretdb/post_install.md
@@ -1,10 +1,11 @@
 ## FerretDB –  a truly Open Source MongoDB alternative
 
-Please note that this version of FerretDB is highly experimental and will not persist your data.
-
 ### External access
 
-By default external access to the FerretDB port isn't available. This is easily changed by applying the following YAML to your cluster with `kubectl apply -f ferretdb-service.yaml` (or whatever you call the file containing the contents below) which will launch a [Civo Load Balancer](https://www.civo.com/load-balancers) (at an additional charge):
+By default, external access to the FerretDB port isn't available. 
+This could be changed by applying the following YAML to your cluster with `kubectl apply -f ferretdb-service.yaml` 
+(or whatever you call the file containing the contents below) 
+which will launch a [Civo Load Balancer](https://www.civo.com/load-balancers) (at an additional charge):
 
 ```
 apiVersion: v1
@@ -21,4 +22,8 @@ spec:
     app: ferretdb
 ```
 
-This will open up YOUR_CLUSTER_ID.k8s.civo.com:27017 to the whole world. You should lock this down in the [firewall](https://www.civo.com/account/firewalls) automatically created in Civo for your Kubernetes cluster. Locking down the firewall will only affect access from OUTSIDE of your Kubernetes cluster, access from your applications within Kubernetes will not be affected.
+This will open up `YOUR_CLUSTER_ID.k8s.civo.com:27017` to the whole world. 
+You should lock this down in the [firewall](https://www.civo.com/account/firewalls) 
+automatically created in Civo for your Kubernetes cluster. 
+Locking down the firewall will only affect access from OUTSIDE of your Kubernetes cluster, 
+access from your applications within Kubernetes will not be affected.


### PR DESCRIPTION

- This PR provides a configuration for FerretDB 1.0. 
- The pod with the app consists of two containers: FerretDB itself and a separate PostgreSQL container. This approach follows the [official FerretDB documentation](https://docs.ferretdb.io/quickstart-guide/docker/).
- Only FerretDB's port (`27017`) is exposed as service port.

---

Existing Marketplace application checklist:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot).
* [x] Updated the version number of the app if that has changed.
