### PR TITLE
Bumps Acorn version to v0.7.1

### DIFF
--- a/acorn/app.yaml
+++ b/acorn/app.yaml
@@ -21,14 +21,14 @@ roleRef:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: acorn-init-v051
+  name: acorn-init-v071
   namespace: kube-system
 spec:
   template:
     spec:
       containers:
         - name: acorn-init
-          image: ghcr.io/acorn-io/acorn:v0.6.0
+          image: ghcr.io/acorn-io/acorn:v0.7.1
           command: ["acorn", "init", "--cluster-domain=$CLUSTER_ID.k8s.civo.com", "--lets-encrypt=$ENABLE_TLS", "--lets-encrypt-email=$USER_EMAIL", "--lets-encrypt-tos-agree=true"]
       restartPolicy: Never
       serviceAccountName: acorn-init

--- a/acorn/manifest.yaml
+++ b/acorn/manifest.yaml
@@ -1,6 +1,6 @@
 ---
 name: Acorn
-version: 0.6.0
+version: 0.7.1
 maintainer: darren@acorn.io, saiyam@civo.com, daniel.bodky@netways.de
 description: A simple application deployment framework for Kubernetes
 url: https://acorn.io


### PR DESCRIPTION
This PR bumps the marketplace version of [acorn](https://acorn.io) from v0.6.0 to v0.7.1.
I thoroughly tested the updated version on a fresh Civo cluster, but did not take a screenshot of my terminal (there's nothing else to see/show).

If your pull request concerns an existing Marketplace application, please make sure you have:

* [X] Notified the Maintainer of the application in this pull request so that they are aware of your proposal. (I'm one of the maintainers)
* [X] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [X] Tested that the application works with the proposed updates applied (including a screenshot).
* [X] Updated the version number of the app if that has changed.
