### PR TITLE
Feat: bump KubeVela to 1.9.4

### DIFF
--- a/kubevela/install.sh
+++ b/kubevela/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-curl -fsSl https://static.kubevela.net/script/install.sh | sudo bash -s 1.5.3
+curl -fsSl https://kubevela.io/script/install.sh | sudo bash -s 1.9.4
 vela install
 
 ## enable velaux by default

--- a/kubevela/manifest.yaml
+++ b/kubevela/manifest.yaml
@@ -1,6 +1,6 @@
 ---
 name: KubeVela
-version: 0.2.0
+version: 1.0.0
 maintainer: qiaozhongpei.qzp@alibaba-inc.com
 description: The Modern Application Platform.
 url: https://kubevela.io


### PR DESCRIPTION
This PR Bump KubeVela to its first major version (1.0.0) in civo marketplace with following components:

- KubeVela core 1.9.4
- VelaUX 1.9.2

Fixes: #485

Thank you for wanting to submit a Pull Request to the Civo Kubernetes Marketplace repository!


If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [ ] Tested that the application works with the proposed updates applied (including a screenshot).
* [x] Updated the version number of the app if that has changed.
