### PR TITLE
Updating Ambassador Edge Stack version to latest 3.8.0

### DIFF
--- a/ambassador-edge-stack/install.sh
+++ b/ambassador-edge-stack/install.sh
@@ -6,10 +6,10 @@ helm repo add datawire https://www.getambassador.io
 helm repo update
 
 #Install CRD's
-kubectl apply -f https://app.getambassador.io/yaml/edge-stack/2.1.2/aes-crds.yaml
+kubectl apply -f https://app.getambassador.io/yaml/edge-stack/3.8.0/aes-crds.yaml
 kubectl wait --timeout=90s --for=condition=available deployment emissary-apiext -n emissary-system
 
 #Install stack
-helm install -n ambassador --create-namespace edge-stack datawire/edge-stack --set controller.image.tag=2.1.2  && kubectl rollout status  -n ambassador deployment/edge-stack -w
-
-
+helm install -n ambassador --create-namespace edge-stack datawire/edge-stack --set controller.image.tag=3.8.0 --set emissary-ingress.createDefaultListeners=true
+# --set emissary-ingress.agent.cloudConnectToken=<CLOUD KEY>
+# steps to retrieve Cloud key is listed in the post installation docs

--- a/ambassador-edge-stack/manifest.yaml
+++ b/ambassador-edge-stack/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: ambassador-edge-stack
 title: "Ambassador Edge Stack"
-version: "2.1.2"
+version: "3.8.0"
 maintainer: "@milindchawre, saiyam@civo.com"
 description: Ambassador Edge Stack is a Kubernetes-native API Gateway built on the Envoy Proxy which can route and secure traffic to your kubernetes cluster.
 url: https://www.getambassador.io/docs/edge-stack/

--- a/ambassador-edge-stack/post_install.md
+++ b/ambassador-edge-stack/post_install.md
@@ -4,7 +4,16 @@ This app create a service edge-stack of type LoadBalancer  which will launch a [
 
 [Ambassador Edge Stack](https://www.getambassador.io/docs/edge-stack/) is a Kubernetes-native API Gateway built on the Envoy Proxy which can route and secure traffic to your kubernetes cluster.
 
+### Pre-Requisites
+
+To sucessfully configure Ambassador Edge Stack, you need to get free community license for your ambassador cloud by [following this guide](https://www.getambassador.io/docs/edge-stack/3.8/tutorials/getting-started#1-installation).
+
+Run below command to reconfigure Ambassador Edge Stack with the Ambassador cloud key obtained in above step.
+```
+helm upgrade --install -n ambassador --create-namespace edge-stack datawire/edge-stack --set controller.image.tag=3.8.0 --set emissary-ingress.createDefaultListeners=true --set emissary-ingress.agent.cloudConnectToken=<your key from Ambassador Cloud> && kubectl rollout status  -n ambassador deployment/edge-stack -w
+```
+
 ### Get started
 
-[Quickstart guide for ambassador edge stack.](https://www.getambassador.io/docs/edge-stack/1.13/tutorials/getting-started/)
+[Quickstart guide for ambassador edge stack.](https://www.getambassador.io/docs/edge-stack/3.8/tutorials/getting-started/)
 

--- a/ambassador-edge-stack/uninstall.sh
+++ b/ambassador-edge-stack/uninstall.sh
@@ -11,4 +11,4 @@ helm uninstall ambassador
 kubectl delete namespace $NS
 
 # Delete CRDs
-kubectl delete -f https://app.getambassador.io/yaml/edge-stack/2.1.2/aes-crds.yaml
+kubectl delete -f https://app.getambassador.io/yaml/edge-stack/3.8.0/aes-crds.yaml


### PR DESCRIPTION
Updated Ambassador Edge Stack to latest 3.8.0 version.
Also successfully tested the application routing.

<img width="631" alt="image" src="https://github.com/civo/kubernetes-marketplace/assets/21288765/20e9e6b4-af6d-4e68-a4d7-47a5c039ee31">
