### PR TITLE
Updating Kong Ingress Controller version to latest 2.11

### DIFF
--- a/kong-ingress-controller/install.sh
+++ b/kong-ingress-controller/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-KONG_VERSION=2.5
-KONG_INGRESS_VERSION=1.3.1
+KONG_VERSION=3.3
+KONG_INGRESS_VERSION=2.11
 NS=kong
 
 # Add the Helm repository for Kong Ingress Controller
@@ -11,4 +11,3 @@ helm repo update
 # Create the namespace and install the Helm chart
 kubectl create namespace $NS
 helm install kong kong/kong --set ingressController.installCRDs=false --set ingressController.image.tag=$KONG_INGRESS_VERSION --set image.tag=$KONG_VERSION --namespace $NS
-

--- a/kong-ingress-controller/manifest.yaml
+++ b/kong-ingress-controller/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: kong-ingress-controller
 title: "Kong Ingress Controller"
-version: "1.3.1"
+version: "2.11"
 maintainer: "@milindchawre"
 description: Kong Ingress Controller is open-source Ingress Controller for Kubernetes that offers API management capabilities with a plugin architecture.
 url: https://docs.konghq.com/kubernetes-ingress-controller/

--- a/kong-ingress-controller/post_install.md
+++ b/kong-ingress-controller/post_install.md
@@ -4,5 +4,5 @@
 
 ### Get started
 
-[Quickstart guide for kong ingress controller.](https://docs.konghq.com/kubernetes-ingress-controller/1.3.x/guides/getting-started/)
+[Quickstart guide for kong ingress controller.](https://docs.konghq.com/kubernetes-ingress-controller/2.11.x/guides/getting-started/)
 


### PR DESCRIPTION
Fixes #495 
Updating Kong Ingress Controller to latest 2.11 version.

<img width="891" alt="image" src="https://github.com/civo/kubernetes-marketplace/assets/21288765/c7b560cd-42da-411d-b444-da6674f12094">

