### PR TITLE
fix(updatecli): always use latest cert-manager using semver

### DIFF
--- a/.github/updatecli/updatecli.d/cert-manager.yaml
+++ b/.github/updatecli/updatecli.d/cert-manager.yaml
@@ -11,6 +11,10 @@ sources:
       repository: cert-manager
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versionfilter:
+        # The cert-manager maintains multiple release line and we want to be sure to pick
+        # the latest one based on semantic versioning rules and not the latest release.
+        kind: semver
 
 targets:
   manifest:
@@ -33,7 +37,7 @@ targets:
       replacepattern: '/download/{{ source "app" }}/'
 
 # Define git repository configuration to know where to push changes
-# Values are templated and provided via the values.yaml so we can easily 
+# Values are templated and provided via the values.yaml so we can easily
 # adapt to the repository owner.
 scms:
   kubernetes-marketplace:


### PR DESCRIPTION
This pullrequest updates the Updatecli manifest for cert-manager to monitor a different "latest" cert-manager version.
To avoid futur pullrequest like this one https://github.com/civo/kubernetes-marketplace/pull/604

As I explain in the comment, the cert-manager project maintains multiple release line and we want to be sure to pick
the latest one based on semantic versioning rules and not the latest released.

They are different ways to understand the meaning of "latest" and I think in this particular situation semantic versioning seems to better. Another option would be to only monitor GitHub release tagged "latest"