### PR TITLE
fix: remove rc version from Rancher

### DIFF
--- a/.github/updatecli/updatecli.d/rancher.yaml
+++ b/.github/updatecli/updatecli.d/rancher.yaml
@@ -27,8 +27,8 @@ targets:
     disablesourceinput: true
     spec:
       file: rancher/install.sh
-      matchpattern: '--version (v{0,1})(\d*.\d*.\d*)'
-      replacepattern: '--version {{ source "chart" }}'
+      matchpattern: 'RANCHER_VERSION=(.*)'
+      replacepattern: 'RANCHER_VERSION="{{ source "chart" }}"'
 
 # Define git repository configuration to know where to push changes
 # Values are templated and provided via the values.yaml so we can easily 

--- a/rancher/install.sh
+++ b/rancher/install.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+RANCHER_VERSION="2.8.3"
+
 subdomain="rancher.${CLUSTER_ID}.k8s.civo.com"
 email="${EMAIL}"
 echo "$subdomain"
@@ -19,4 +21,4 @@ helm repo update
 kubectl create namespace cattle-system
 
   
-helm upgrade --install rancher rancher-latest/rancher --namespace cattle-system --set hostname="$subdomain" --set bootstrapPassword="${ADMIN_PASS}" --set ingress.tls.source=letsEncrypt --set letsEncrypt.ingress.class=traefik --set letsEncrypt.email="${EMAIL}" --version 2.8.3-rc3
+helm upgrade --install rancher rancher-latest/rancher --namespace cattle-system --set hostname="$subdomain" --set bootstrapPassword="${ADMIN_PASS}" --set ingress.tls.source=letsEncrypt --set letsEncrypt.ingress.class=traefik --set letsEncrypt.email="${EMAIL}" --version "$RANCHER_VERSION"


### PR DESCRIPTION
Fix Rancher version deployed

I don't know when or how but apparently a `rc-3` crept in the Rancher version.
This pull request modifies the rancher installation script to rely on a variable which is easier to update with a regex