### PR TITLE
Update jenkins install.sh with the correct keys

### DIFF
--- a/jenkins/install.sh
+++ b/jenkins/install.sh
@@ -6,5 +6,5 @@ helm repo update
 kubectl create namespace jenkins
 
 helm install jenkins jenkins/jenkins --version 5.1.5 --namespace jenkins --set persistence.size=${VOLUME_SIZE} \
---set controller.adminUser=${JENKINS_USERNAME} \
---set controller.adminPassword=${JENKINS_PASSWORD}
+--set controller.admin.username=${JENKINS_USERNAME} \
+--set controller.admin.password=${JENKINS_PASSWORD}


### PR DESCRIPTION
Hi @saiyam1814. I think the installation script doesn't work anymore. I tried creating new kubernetes cluster with jenkins installed and I found an error.

```
{"time":"2024-04-19T14:42:29.691030802Z","level":"INFO","msg":"Command output","stdout":"\"jenkins\" has been added to your repositories\nHang tight while we grab the latest from your chart repositories...\n...Successfully got an update from the \"jenkins\" chart repository\nUpdate Complete. ⎈Happy Helming!⎈\nnamespace/jenkins created\n"}
{"time":"2024-04-19T14:42:29.691166777Z","level":"ERROR","msg":"Command output","stderr":"Error: INSTALLATION FAILED: execution error at (jenkins/templates/deprecation.yaml:129:6): `controller.adminUser` no longer exists. It has been renamed to `controller.admin.username`\n"}
Error: exit status 1
Usage:
  marketplace-installer install [flags]

Examples:
install <app name>

Flags:
  -h, --help   help for install

Global Flags:
  -d, --git-url string   The git repo to clone from (default "https://git.civo.com/civo/marketplace.git")
```

I think now the jenkins helm chart expect `controller.admin.username` and `controller.admin.password`.

https://github.com/jenkinsci/helm-charts/blob/jenkins-5.1.5/charts/jenkins/values.yaml#L78