### PR TITLE
spinkube: bump to 0.2.0

### DIFF
--- a/spinkube/install.sh
+++ b/spinkube/install.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
+
+SPINKUBE_VERSION="0.2.0"
+
 #Check we are on Talos
-if $(kubectl get nodes -o json | jq .items.[].status.nodeInfo.osImage | grep -q "Talos"); then 
+if $(kubectl get nodes -o json | jq .items.[].status.nodeInfo.osImage | grep -q "Talos"); then
     echo "Found Talos as part of OS Image string"; else
     echo "Did not find Talos as part of the OS Image string. Exiting as only Talos is supported" ;
     exit
 fi
 
-#Cert manager check 
-#If namespace, or deployment is not found, the wait command below will fail, and the script continues. 
-until $(kubectl get namespaces cert-manager -o name --ignore-not-found | grep -q "namespace/cert-manager"); do 
-    echo "Waiting for cert-manager namespace creation"; 
+#Cert manager check
+#If namespace, or deployment is not found, the wait command below will fail, and the script continues.
+until $(kubectl get namespaces cert-manager -o name --ignore-not-found | grep -q "namespace/cert-manager"); do
+    echo "Waiting for cert-manager namespace creation";
     sleep 1;
 done
 
@@ -18,14 +21,14 @@ until $(kubectl get deployment cert-manager-webhook -n cert-manager --ignore-not
     sleep 1;
 done
 
-kubectl wait --for=condition=available --timeout=300s deployment/cert-manager-webhook  -n cert-manager 
+kubectl wait --for=condition=available --timeout=300s deployment/cert-manager-webhook  -n cert-manager
 
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
-kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v${SPINKUBE_VERSION}/spin-operator.runtime-class.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v${SPINKUBE_VERSION}/spin-operator.crds.yaml
+kubectl apply -f https://github.com/spinkube/spin-operator/releases/download/v${SPINKUBE_VERSION}/spin-operator.shim-executor.yaml
 helm install spin-operator \
   --namespace spin-operator \
   --create-namespace \
-  --version 0.1.0 \
+  --version ${SPINKUBE_VERSION} \
   --wait \
   oci://ghcr.io/spinkube/charts/spin-operator

--- a/spinkube/manifest.yaml
+++ b/spinkube/manifest.yaml
@@ -1,8 +1,8 @@
 ---
 name: spinkube
 title: Spinkube
-version: v0.1.0
-maintainer: "@kunal-kushwaha, radu@fermyon.com"
+version: v0.2.0
+maintainer: "@kunal-kushwaha, radu@fermyon.com, danielle@fermyon.com"
 description: Operator that helps to deploy Spin applications to your Kubernetes clusters.
 url: https://github.com/spinkube/spin-operator
 category: management

--- a/spinkube/uninstall.sh
+++ b/spinkube/uninstall.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
+SPINKUBE_VERSION="0.2.0"
+
 # Uninstall Spin Operator using Helm
 helm uninstall spin-operator --namespace spin-operator
 
 # Uninstall all resources related to spin-operator including CRD resources
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.runtime-class.yaml
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.crds.yaml
-kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v0.1.0/spin-operator.shim-executor.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v${SPINKUBE_VERSION}/spin-operator.runtime-class.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v${SPINKUBE_VERSION}/spin-operator.crds.yaml
+kubectl delete -f https://github.com/spinkube/spin-operator/releases/download/v${SPINKUBE_VERSION}/spin-operator.shim-executor.yaml
 
 # Delete Namespace
 kubectl delete ns spin-operator


### PR DESCRIPTION
* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal. (@radu-matei / @saiyam1814)
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot).
* [x] Updated the version number of the app if that has changed.

I haven't tested this yet (was testing something else on Civo and remembered we cut a release last week), but I can do so later.

[Changelog](https://github.com/spinkube/spin-operator/releases/tag/v0.2.0), the main new feature being ensuring that SpinApps have TLS certs for outbound connections: https://github.com/spinkube/spin-operator/pull/207