### PR TITLE
updated ingress yaml to be valid for current k8s versions

### DIFF
--- a/traefik2-loadbalancer/post_install.md
+++ b/traefik2-loadbalancer/post_install.md
@@ -25,9 +25,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: yourapp-service
-          servicePort: http
+          service:
+            name: nginx
+            port:
+              number: 80
 ```
 
 Traefik also includes a CRD called IngressRoute, which would look like this:


### PR DESCRIPTION
Updating the post install steps for traefik LB, as the ingress YAML was invalid.