### PR TITLE
fix cyclops manifest name

### DIFF
--- a/cyclops/manifest.yaml
+++ b/cyclops/manifest.yaml
@@ -1,5 +1,5 @@
 ---
-name: cyclops-ui
+name: cyclops
 title: "Cyclops UI"
 version: "v0.8.2"
 maintainer: "info@cyclops-ui.com"


### PR DESCRIPTION
marketplace-installer fails to start Cyclops with
```
Error: stat /tmp/prefix/cyclops-ui: no such file or directory
```

My guess is that the manifest name (`cyclops-ui`) and folder name (`cyclops`) do now match. PR updates manifest name to `cyclops`. Let me know if the better approach is to rename the folder or something else is at fault\

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot).
* [x] Updated the version number of the app if that has changed.