### PR TITLE
bump Cyclops to v0.11.1

### DIFF
--- a/cyclops/install.sh
+++ b/cyclops/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install Cyclops
-kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/v0.10.0/install/cyclops-install.yaml
+kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/v0.11.1/install/cyclops-install.yaml
 
 # Add Cyclops app templates
-kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/v0.10.0/install/demo-templates.yaml
+kubectl apply -f https://raw.githubusercontent.com/cyclops-ui/cyclops/v0.11.1/install/demo-templates.yaml

--- a/cyclops/manifest.yaml
+++ b/cyclops/manifest.yaml
@@ -1,7 +1,7 @@
 ---
 name: cyclops
 title: "Cyclops UI"
-version: "v0.10.0"
+version: "v0.11.1"
 maintainer: "info@cyclops-ui.com"
 description: "Customizable UI for Kubernetes applications"
 url: https://cyclops-ui.com/

--- a/cyclops/uninstall.sh
+++ b/cyclops/uninstall.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Delete cyclops
-kubectl delete -f https://raw.githubusercontent.com/cyclops-ui/cyclops/v0.10.0/install/cyclops-install.yaml
+kubectl delete -f https://raw.githubusercontent.com/cyclops-ui/cyclops/v0.11.1/install/cyclops-install.yaml


### PR DESCRIPTION
Bumping Cyclops to `v0.11.1`

If your pull request concerns an existing Marketplace application, please make sure you have:

* [x] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [x] Tested that the application works with the proposed updates applied (including a screenshot).
<img width="1512" alt="Screenshot 2024-09-13 at 16 42 12" src="https://github.com/user-attachments/assets/ead7c41c-74a9-44d9-bc6c-87ef488421aa">
* [x] Updated the version number of the app if that has changed.
