### PR TITLE
Remove trailing list item

### DIFF
--- a/flux/post_install.md
+++ b/flux/post_install.md
@@ -23,7 +23,6 @@ To get started with Flux, [browse the documentation](https://fluxcd.io) or try t
 - [Manage multi-tenant clusters with Flux](https://github.com/fluxcd/flux2-multi-tenancy)
 - [Automating Kubernetes Deployments with GitOps and Flux](https://www.civo.com/learn/gitops-and-flux)
 - [Automate GitOps Pipeline for Node.js with Flux CD on Kubernetes](https://www.civo.com/learn/gitops-using-helm3-and-flux-for-an-node-js-and-express-js-microservice)
-- 
 
 ## Upgrade instruction
 


### PR DESCRIPTION
This PR removes the empty trailing list item which causes the final link to render incorrectly as a heading

![Screenshot 2024-10-27 at 1 35 51 PM](https://github.com/user-attachments/assets/5cdf65be-6a6f-4196-84f3-26a40e781ed1)

