### PR TITLE
bump required ruby version 3.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.0.0-node
+      - image: cimg/ruby:3.1.0-node
         environment:
           BUNDLER_VERSION: 2.0.2
     working_directory: ~/repo


### PR DESCRIPTION
looks like it needs a new ruby version
🔴 requires 3.1.0 currently 3.0.0
- https://app.circleci.com/pipelines/github/civo/kubernetes-marketplace/6481/workflows/ddf74b91-c590-44c9-89fa-ade8bc1cfe6e/jobs/6439?invite=true#step-103-65_90

🟢 change passes
- https://app.circleci.com/pipelines/github/civo/kubernetes-marketplace?branch=pull%2F1004