### PR TITLE
Fix: make Traefik2-nodeport to use a different port than 9100

### DIFF
--- a/traefik2-nodeport/app.yaml
+++ b/traefik2-nodeport/app.yaml
@@ -100,7 +100,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/path: /metrics
-        prometheus.io/port: "9100"
+        prometheus.io/port: "9910"
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/instance: traefik-kube-system
@@ -110,7 +110,7 @@ spec:
       - args:
         - --global.checknewversion
         - --global.sendanonymoususage
-        - --entrypoints.metrics.address=:9100/tcp
+        - --entrypoints.metrics.address=:9910/tcp
         - --entrypoints.traefik.address=:9000/tcp
         - --entrypoints.web.address=:80/tcp
         - --entrypoints.websecure.address=:443/tcp
@@ -136,8 +136,8 @@ spec:
           timeoutSeconds: 2
         name: traefik
         ports:
-        - containerPort: 9100
-          hostPort: 9100
+        - containerPort: 9910
+          hostPort: 9910
           name: metrics
           protocol: TCP
         - containerPort: 9000

--- a/traefik2-nodeport/post_install.md
+++ b/traefik2-nodeport/post_install.md
@@ -61,3 +61,7 @@ spec:
 This will open up `http://www.example.com` (assuming you pointed that non-real domain record to your cluster's IPs) to the whole world.
 
 Port 80 and 443 are both exposed through a `NodePort` service.
+
+## Metrics and Monitoring
+
+Traefik exposes metrics on port 9910 for Prometheus scraping. To scrape metrics from Traefik, ensure your Prometheus configuration is updated to use port **9910**.


### PR DESCRIPTION
## Gist:

**Background:**

It fixes one recent issue reported by an user, in which he tried to install `node-exporter` in the k8s cluster, which by default uses port 9100, and since `Traefik2-nodeport` already uses that port, he wasn't able to install `node-exporter`.

**What I have done?**

I changed it to use a less common port 9910, it is less likely to conflict with other applications.

## Details:

**Simple ways to reproduce the issue:**

1. Create a `traefik-config.yaml`, put in the config. [here](https://github.com/civo/kubernetes-marketplace/blob/b3fd86c23fec4e385bda606824eddb2f3e474309/traefik2-nodeport/app.yaml)

2. Do `kubectl apply -f traefik-config.yaml`

3. Create `daemonset.yaml`:
```yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    app.kubernetes.io/component: exporter
    app.kubernetes.io/name: node-exporter
  name: node-exporter
  namespace: kube-system
spec:
  selector:
    matchLabels:
      app.kubernetes.io/component: exporter
      app.kubernetes.io/name: node-exporter
  template:
    metadata:
      labels:
        app.kubernetes.io/component: exporter
        app.kubernetes.io/name: node-exporter
    spec:
      containers:
      - args:
        - --path.sysfs=/host/sys
        - --path.rootfs=/host/root
        - --no-collector.wifi
        - --no-collector.hwmon
        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
        - --collector.netclass.ignored-devices=^(veth.*)$
        name: node-exporter
        image: prom/node-exporter
        ports:
          - containerPort: 9100
            hostPort: 9100
            protocol: TCP
        resources:
          limits:
            cpu: 250m
            memory: 180Mi
          requests:
            cpu: 102m
            memory: 180Mi
        volumeMounts:
        - mountPath: /host/sys
          mountPropagation: HostToContainer
          name: sys
          readOnly: true
        - mountPath: /host/root
          mountPropagation: HostToContainer
          name: root
          readOnly: true
      volumes:
      - hostPath:
          path: /sys
        name: sys
      - hostPath:
          path: /
        name: root
```

4. Run `kubectl apply -f daemonset.yaml`

5. Create `service.yaml`:
```yaml
---
kind: Service
apiVersion: v1
metadata:
  name: node-exporter
  namespace: kube-system
  annotations:
      prometheus.io/scrape: 'true'
      prometheus.io/port:   '9100'
spec:
  selector:
      app.kubernetes.io/component: exporter
      app.kubernetes.io/name: node-exporter
  ports:
  - name: node-exporter
    protocol: TCP
    port: 9100
    targetPort: 9100
```

6. Run `kubectl apply -f service.yaml`

Now if you do, `kubectl get pods -n kube-system`. You'll find the `nod-exporter` pod in pending state:

<img width="714" alt="Screenshot 2025-01-21 at 3 15 30 AM" src="https://github.com/user-attachments/assets/cc0775f5-b5a6-4e31-9c2b-fcff8131c812" />


Now do, `kubectl describe pods -n kube-system node-exporter-87d4f`, You will see the port unavailable error:

<img width="1118" alt="Screenshot 2025-01-21 at 3 18 33 AM" src="https://github.com/user-attachments/assets/eff5cd7c-616c-44e6-95f7-1811e5167f8a" />


Now if you update the port as done in this PR and apply the changes, You will get the `node-exporter` pod in running state, here's the result:

<img width="594" alt="Screenshot 2025-01-21 at 3 20 40 AM" src="https://github.com/user-attachments/assets/c0eb5d88-6caa-42bd-8b82-31e6fb45bbf2" />

