### PR TITLE
fix: patch long-horn uninstall

### DIFF
--- a/longhorn/uninstall.sh
+++ b/longhorn/uninstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+kubectl -n longhorn-system patch settings.longhorn.io deleting-confirmation-flag --type='merge' -p '{"value":"true"}'
 helm uninstall longhorn -n longhorn-system
 kubectl delete namespace longhorn-system


### PR DESCRIPTION
## Description

The `helm uninstall` for long horn fails with following error 
```
time="2025-03-22T01:15:58Z" level=fatal msg="cannot uninstall Longhorn because deleting-confirmation-flag is set to `false`. Please set it to `true` using Longhorn UI or kubectl -n longhorn-system edit settings.longhorn.io deleting-confirmation-flag " func=app.UninstallCmd.func1 file="uninstall.go:48" do using kubectl
```

## Test
Install the cluster with market-place application selected as long-horn,then uninstall using below  
```
kubectl -n longhorn-system patch settings.longhorn.io deleting-confirmation-flag --type='merge' -p '{"value":"true"}'
helm uninstall longhorn -n longhorn-system
kubectl delete namespace longhorn-system
```