### PR TITLE
fix: Linkerd install broken - add --crds step and update install URL

### DIFF
--- a/linkerd/install.sh
+++ b/linkerd/install.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 
-curl -sL https://run.linkerd.io/install | sh
+curl -sL https://run.linkerd.io/install-edge | sh
 export PATH=$PATH:$HOME/.linkerd2/bin
 
-linkerd check --pre && linkerd install | kubectl apply -f -
+# Validate that Linkerd can be installed
+linkerd check --pre || exit 1
+
+# Install Linkerd CRDs first (required since Linkerd v2.12+)
+linkerd install --crds | kubectl apply -f -
+
+# Install the Linkerd control plane
+linkerd install | kubectl apply -f -
+
 case ${LINKERD} in
   linkerd)
     linkerd check || exit 1
     ;;
-  linkerdjaeger)  
+  linkerdjaeger)
     linkerd check || exit 1
     linkerd jaeger install | kubectl apply -f -
     linkerd check || exit 1


### PR DESCRIPTION
## Problem

Fixes #1065 — Linkerd install was broken for all plans.

The install was failing with:

```
Linkerd CRDs must be installed first. Run linkerd install with the --crds flag.
error: no objects passed to apply
```

## Root Cause

Two issues in `linkerd/install.sh`:

1. **Deprecated install script URL** — `https://run.linkerd.io/install` no longer installs stable releases, only edge builds. Updated to `https://run.linkerd.io/install-edge`.

2. **Missing `--crds` step** — Since Linkerd v2.12+, CRDs must be installed as a separate step before the control plane. The old script ran `linkerd install | kubectl apply -f -` directly, which fails without the CRDs being present first.

## Fix

```diff
- curl -sL https://run.linkerd.io/install | sh
+ curl -sL https://run.linkerd.io/install-edge | sh

- linkerd check --pre && linkerd install | kubectl apply -f -
+ linkerd check --pre || exit 1
+ linkerd install --crds | kubectl apply -f -
+ linkerd install | kubectl apply -f -
```
