### PR TITLE
Create uninstall.sh for Traefik2 NodePort

### DIFF
--- a/traefik2-nodeport/uninstall.sh
+++ b/traefik2-nodeport/uninstall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Delete all k8s resources of this app
+kubectl delete -f https://raw.githubusercontent.com/civo/kubernetes-marketplace/master/traefik2-nodeport/app.yaml


### PR DESCRIPTION
Addition of the uninstall script for traefik2-nodeport to allow k3s clusters to be used with a different ingress
